### PR TITLE
[REVIEW] Adding Hash Bucket Op

### DIFF
--- a/nvtabular/groupby.py
+++ b/nvtabular/groupby.py
@@ -288,7 +288,7 @@ class GroupByMomentsCal(object):
                 for cont_name in self.cont_col:
                     for su_op in self.supported_ops:
                         if su_op in self.stats_names:
-                            if su_op == 'count':
+                            if su_op == "count":
                                 new_col = self.col + "_count"
                                 self.stats[new_col] = result_map[su_op][cont_name]
                             else:

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -654,43 +654,6 @@ class HashBucket(TransformOperator):
         return new_gdf
 
 
-class HashBucket(TransformOperator):
-    default_in = CAT
-    default_out = CAT
-
-    def __init__(self, num_buckets, columns=None, **kwargs):
-        if isinstance(num_buckets, dict):
-            columns = [i for i in num_buckets.keys()]
-            self.num_buckets = num_buckets
-        elif isinstance(num_buckets, (tuple, list)):
-            assert columns is not None
-            assert len(columns) == len(num_buckets)
-            self.num_buckets = {col: nb for col, nb in zip(columns, num_buckets)}
-        elif isinstance(num_buckets, int):
-            self.num_buckets = num_buckets
-        else:
-            raise TypeError(
-                "`num_buckets` must be dict, iterable, or int, got type {}".format(
-                    type(num_buckets)
-                )
-            )
-        super(HashBucket, self).__init__(columns=columns, **kwargs)
-
-    @annotate("HashBucket_op", color="darkgreen", domain="nvt_python")
-    def op_logic(self, gdf: cudf.DataFrame, target_columns: list, stats_context=None):
-        cat_names = target_columns
-        if isinstance(self.num_buckets, int):
-            num_buckets = {name: self.num_buckets for name in cat_names}
-        else:
-            num_buckets = self.num_buckets
-
-        new_gdf = cudf.DataFrame()
-        for col, nb in num_buckets.items():
-            new_col = f"{col}_{self._id}"
-            new_gdf[new_col] = gdf[col].hash_values() % nb
-        return new_gdf
-
-
 class Normalize(DFOperator):
     """
     Standardizing the features around 0 with a standard deviation

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -652,6 +652,41 @@ class HashBucket(TransformOperator):
         return new_gdf
 
 
+class HashBucket(TransformOperator):
+    default_in = CAT
+    default_out = CAT
+
+    def __init__(self, num_buckets, columns=None, **kwargs):
+        if isinstance(num_buckets, dict):
+            columns = [i for i in num_buckets.keys()]
+            self.num_buckets = num_buckets
+        elif isinstance(num_buckets, (tuple, list)):
+            assert columns is not None
+            assert len(columns) == len(num_buckets)
+            self.num_buckets = {
+                col: nb for col, nb in zip(columns, num_buckets)}
+        elif isinstance(num_buckets, int):
+            self.num_buckets = num_buckets
+        else:
+            raise TypeError(
+              "`num_buckets` must be dict, iterable, or int, got type {}".format(type(num_buckets)))
+        super(HashBucket, self).__init__(columns=columns, **kwargs)
+
+    @annotate("HashBucket_op", color="darkgreen", domain="nvt_python")
+    def op_logic(self, gdf: cudf.DataFrame, target_columns: list, stats_context=None):
+        cat_names = target_columns
+        if isinstance(self.num_buckets, int):
+            num_buckets = {name: self.num_buckets for name in cat_names}
+        else:
+            num_buckets = self.num_buckets
+
+        new_gdf = cudf.DataFrame()
+        for col, nb in num_buckets.items():
+            new_col = f"{col}_{self._id}"
+            new_gdf[new_col] = gdf[col].hash_values() % nb
+        return new_gdf
+
+
 class Normalize(DFOperator):
     """
     Standardizing the features around 0 with a standard deviation

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -628,13 +628,15 @@ class HashBucket(TransformOperator):
         elif isinstance(num_buckets, (tuple, list)):
             assert columns is not None
             assert len(columns) == len(num_buckets)
-            self.num_buckets = {
-                col: nb for col, nb in zip(columns, num_buckets)}
+            self.num_buckets = {col: nb for col, nb in zip(columns, num_buckets)}
         elif isinstance(num_buckets, int):
             self.num_buckets = num_buckets
         else:
             raise TypeError(
-              "`num_buckets` must be dict, iterable, or int, got type {}".format(type(num_buckets)))
+                "`num_buckets` must be dict, iterable, or int, got type {}".format(
+                    type(num_buckets)
+                )
+            )
         super(HashBucket, self).__init__(columns=columns, **kwargs)
 
     @annotate("HashBucket_op", color="darkgreen", domain="nvt_python")
@@ -663,13 +665,15 @@ class HashBucket(TransformOperator):
         elif isinstance(num_buckets, (tuple, list)):
             assert columns is not None
             assert len(columns) == len(num_buckets)
-            self.num_buckets = {
-                col: nb for col, nb in zip(columns, num_buckets)}
+            self.num_buckets = {col: nb for col, nb in zip(columns, num_buckets)}
         elif isinstance(num_buckets, int):
             self.num_buckets = num_buckets
         else:
             raise TypeError(
-              "`num_buckets` must be dict, iterable, or int, got type {}".format(type(num_buckets)))
+                "`num_buckets` must be dict, iterable, or int, got type {}".format(
+                    type(num_buckets)
+                )
+            )
         super(HashBucket, self).__init__(columns=columns, **kwargs)
 
     @annotate("HashBucket_op", color="darkgreen", domain="nvt_python")

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -617,6 +617,41 @@ class LogOp(TransformOperator):
         return new_gdf
 
 
+class HashBucket(TransformOperator):
+    default_in = CAT
+    default_out = CAT
+
+    def __init__(self, num_buckets, columns=None, **kwargs):
+        if isinstance(num_buckets, dict):
+            columns = [i for i in num_buckets.keys()]
+            self.num_buckets = num_buckets
+        elif isinstance(num_buckets, (tuple, list)):
+            assert columns is not None
+            assert len(columns) == len(num_buckets)
+            self.num_buckets = {
+                col: nb for col, nb in zip(columns, num_buckets)}
+        elif isinstance(num_buckets, int):
+            self.num_buckets = num_buckets
+        else:
+            raise TypeError(
+              "`num_buckets` must be dict, iterable, or int, got type {}".format(type(num_buckets)))
+        super(HashBucket, self).__init__(columns=columns, **kwargs)
+
+    @annotate("HashBucket_op", color="darkgreen", domain="nvt_python")
+    def op_logic(self, gdf: cudf.DataFrame, target_columns: list, stats_context=None):
+        cat_names = target_columns
+        if isinstance(self.num_buckets, int):
+            num_buckets = {name: self.num_buckets for name in cat_names}
+        else:
+            num_buckets = self.num_buckets
+
+        new_gdf = cudf.DataFrame()
+        for col, nb in num_buckets.items():
+            new_col = f"{col}_{self._id}"
+            new_gdf[new_col] = gdf[col].hash_values() % nb
+        return new_gdf
+
+
 class Normalize(DFOperator):
     """
     Standardizing the features around 0 with a standard deviation

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -323,8 +323,6 @@ def test_hash_bucket(tmpdir, datasets, gpu_memory_frac, engine, op_columns):
     else:
         columns = mycols_csv
     cat_names = ["name-string"]
-    cont_names = ["x", "y", "id"]
-    label_name = ["label"]
 
     data_itr = nvtabular.io.GPUDatasetIterator(
         paths,

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -303,6 +303,50 @@ def test_log(tmpdir, datasets, gpu_memory_frac, engine, op_columns):
         assert new_gdf[cont_names] == np.log(gdf[cont_names].astype(np.float32))
 
 
+@pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])
+@pytest.mark.parametrize("engine", ["parquet", "csv", "csv-no-header"])
+@pytest.mark.parametrize("op_columns", [["name-string"], None])
+def test_hash_bucket(tmpdir, datasets, gpu_memory_frac, engine, op_columns):
+    paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
+
+    if engine == "parquet":
+        df1 = cudf.read_parquet(paths[0])[mycols_pq]
+        df2 = cudf.read_parquet(paths[1])[mycols_pq]
+    else:
+        df1 = cudf.read_csv(paths[0], header=False, names=allcols_csv)[mycols_csv]
+        df2 = cudf.read_csv(paths[1], header=False, names=allcols_csv)[mycols_csv]
+    df = cudf.concat([df1, df2], axis=0)
+    df["id"] = df["id"].astype("int64")
+
+    if engine == "parquet":
+        cat_names = ["name-cat", "name-string"]
+        columns = mycols_pq
+    else:
+        cat_names = ["name-string"]
+        columns = mycols_csv
+    cont_names = ["x", "y", "id"]
+    label_name = ["label"]
+
+    data_itr = nvtabular.io.GPUDatasetIterator(
+        paths,
+        columns=columns,
+        use_row_groups=True,
+        gpu_memory_frac=gpu_memory_frac,
+        names=allcols_csv,
+    )
+
+    hash_bucket_op = ops.HashBucket({column: 10 for column in op_columns})
+
+    columns_ctx = {}
+    columns_ctx["categorical"] = {}
+    columns_ctx["categorical"]["base"] = cat_names
+
+    for gdf in data_itr:
+        new_gdf = hash_bucket_op.apply_op(gdf, columns_ctx, "categorical")
+        assert np.all(new_gdf[cat_names] >= 0)
+        assert np.all(new_gdf[cat_names] <= 9)
+
+
 def test_fill_missing(tmpdir, datasets, engine="parquet"):
     paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
     columns = mycols_pq if engine == "parquet" else mycols_csv


### PR DESCRIPTION
Adding hash bucket op and unit test for reducing categorical cardinality.

One possible feature worth considering for the future (but not strictly necessary) is to make num_buckets a kwarg and conditioning an encoder stat on its being left as None. In this case, the encoder would be used to count categories and a rule of thumb would then be used to decide on number of buckets.

This could even be subsumed into the Categorify op as a sliding scale with the frequency count, where everything beneath the frequency count is hashed to a given number of buckets (either provided explicitly by the user or decided via the statistic and the rule of thumb). The current Categorify behavior would reduce to the case that num_buckets=1, and the HashBucket op reduces to the case that the frequency threshold is set to infinity.