### PR TITLE
[REVIEW] Initial Dask integration in NVTabular

### DIFF
--- a/examples/dask-nvtabular-criteo-benchmark.py
+++ b/examples/dask-nvtabular-criteo-benchmark.py
@@ -112,7 +112,7 @@ def main(args):
 
     # Define Dask NVTabular "Workflow"
     processor = Workflow(
-        cat_names=cat_names, cont_names=cont_names, label_name=label_name, client=client,
+        cat_names=cat_names, cont_names=cont_names, label_name=label_name, client=client
     )
     processor.add_feature([ops.ZeroFill(), ops.LogOp()])
     processor.add_preprocess(
@@ -187,13 +187,9 @@ def parse_args():
         type=str,
         help="Write dask profile report (E.g. dask-report.html)",
     )
-    parser.add_argument(
-        "--data-path", type=str, help="Raw dataset path.",
-    )
+    parser.add_argument("--data-path", type=str, help="Raw dataset path.")
     parser.add_argument("--out-path", type=str, help="Root output path.")
-    parser.add_argument(
-        "--dask-workspace", default=None, type=str, help="Dask workspace path.",
-    )
+    parser.add_argument("--dask-workspace", default=None, type=str, help="Dask workspace path.")
     parser.add_argument(
         "-s", "--splits", default=24, type=int, help="Number of splits to shuffle each partition"
     )
@@ -213,10 +209,7 @@ def parse_args():
         help="Fractional device-memory limit (per worker).",
     )
     parser.add_argument(
-        "--device-pool-frac",
-        default=0.8,
-        type=float,
-        help="Fractional rmm pool size (per worker).",
+        "--device-pool-frac", default=0.8, type=float, help="Fractional rmm pool size (per worker)."
     )
     parser.add_argument(
         "--worker-shuffle", action="store_true", help="Perform followup shuffle on each worker."

--- a/examples/dask-nvtabular-criteo-benchmark.py
+++ b/examples/dask-nvtabular-criteo-benchmark.py
@@ -1,0 +1,254 @@
+# Note: Be sure to clean up output and dask work-space before running test
+
+import argparse
+import os
+import time
+
+import cudf
+import rmm
+
+import nvtabular.ops as ops
+from dask.distributed import Client, performance_report
+from dask_cuda import LocalCUDACluster
+from nvtabular import DaskDataset, Workflow
+
+
+def setup_rmm_pool(client, pool_size):
+    client.run(cudf.set_allocator, pool=True, initial_pool_size=pool_size, allocator="default")
+    return None
+
+
+def main(args):
+
+    # Input
+    data_path = args.data_path
+    out_path = args.out_path
+    freq_limit = args.freq_limit
+    nsplits = args.splits
+    if args.protocol == "ucx":
+        os.environ["UCX_TLS"] = "tcp,cuda_copy,cuda_ipc,sockcm"
+
+    # Use Criteo dataset by default (for now)
+    cont_names = (
+        args.cont_names.split(",") if args.cont_names else ["I" + str(x) for x in range(1, 14)]
+    )
+    cat_names = (
+        args.cat_names.split(",") if args.cat_names else ["C" + str(x) for x in range(1, 27)]
+    )
+    label_name = ["label"]
+
+    if args.cat_splits:
+        split_out = {name: int(s) for name, s in zip(cat_names, args.cat_splits.split(","))}
+    else:
+        split_out = {col: 1 for col in cat_names}
+        if args.cat_names is None:
+            # Using Criteo... Use more hash partitions for
+            # known high-cardinality columns
+            if args.n_workers >= 4:
+                split_out["C20"] = 8
+                split_out["C1"] = 8
+                split_out["C22"] = 4
+                split_out["C10"] = 4
+                split_out["C21"] = 2
+                split_out["C11"] = 2
+                split_out["C23"] = 2
+                split_out["C12"] = 2
+            else:
+                split_out["C20"] = 8
+                split_out["C1"] = 8
+                split_out["C22"] = 4
+                split_out["C10"] = 4
+                split_out["C21"] = 2
+                split_out["C11"] = 2
+                split_out["C23"] = 2
+                split_out["C12"] = 2
+
+    # Specify categorical caching location
+    cat_cache = None
+    if args.cat_cache:
+        cat_cache = args.cat_cache.split(",")
+        if len(cat_cache) == 1:
+            cat_cache = cat_cache[0]
+        else:
+            # If user is specifying a list of options,
+            # they must specify an option for every cat column
+            assert len(cat_names) == len(cat_cache)
+    if isinstance(cat_cache, str):
+        cat_cache = {col: cat_cache for col in cat_names}
+    elif isinstance(cat_cache, list):
+        cat_cache = {name: c for name, c in zip(cat_names, cat_cache)}
+    else:
+        # Criteo/DLRM Defaults
+        cat_cache = {col: "device" for col in cat_names}
+        if args.cat_names is None:
+            cat_cache["C20"] = "host"
+            cat_cache["C1"] = "host"
+            # Only need to cache the largest two on a dgx-2
+            if args.n_workers < 16:
+                cat_cache["C22"] = "host"
+                cat_cache["C10"] = "host"
+
+    # Use total device size to calculate args.device_limit_frac
+    device_size = rmm.get_info().total
+    device_limit = int(args.device_limit_frac * device_size)
+    device_pool_size = int(args.device_pool_frac * device_size)
+    part_size = int(args.part_mem_frac * device_size)
+
+    # Setup LocalCUDACluster
+    if args.protocol == "tcp":
+        cluster = LocalCUDACluster(
+            protocol=args.protocol,
+            n_workers=args.n_workers,
+            CUDA_VISIBLE_DEVICES=args.devs,
+            device_memory_limit=device_limit,
+            local_directory=args.dask_workspace,
+            dashboard_address=":3787",
+        )
+    else:
+        cluster = LocalCUDACluster(
+            protocol=args.protocol,
+            n_workers=args.n_workers,
+            CUDA_VISIBLE_DEVICES=args.devs,
+            enable_nvlink=True,
+            device_memory_limit=device_limit,
+            local_directory=args.dask_workspace,
+            dashboard_address=":3787",
+        )
+    client = Client(cluster)
+
+    # Setup RMM pool
+    if not args.no_rmm_pool:
+        setup_rmm_pool(client, device_pool_size)
+
+    # Define Dask NVTabular "Workflow"
+    processor = Workflow(
+        cat_names=cat_names, cont_names=cont_names, label_name=label_name, client=client,
+    )
+    processor.add_feature([ops.ZeroFill(), ops.LogOp()])
+    processor.add_preprocess(
+        ops.Categorify(
+            out_path=out_path, split_out=split_out, cat_cache=cat_cache, freq_threshold=freq_limit,
+        )
+    )
+    processor.finalize()
+
+    dataset = DaskDataset(data_path, "parquet", part_size=part_size)
+
+    # Execute the dask graph
+    runtime = time.time()
+    if args.profile is not None:
+        with performance_report(filename=args.profile):
+            processor.apply(
+                dataset,
+                shuffle="full" if args.worker_shuffle else "partial",
+                nsplits=nsplits,
+                output_path=out_path,
+            )
+    else:
+        processor.apply(
+            dataset,
+            shuffle="full" if args.worker_shuffle else "partial",
+            nsplits=nsplits,
+            output_path=out_path,
+        )
+    runtime = time.time() - runtime
+
+    print("\nDask-NVTabular DLRM/Criteo benchmark")
+    print("--------------------------------------")
+    print(f"partition size  | {part_size}")
+    print(f"protocol        | {args.protocol}")
+    print(f"device(s)       | {args.devs}")
+    print(f"rmm-pool        | {(not args.no_rmm_pool)}")
+    print(f"nsplits         | {args.splits}")
+    print(f"worker-shuffle  | {args.worker_shuffle}")
+    print("======================================")
+    print(f"Runtime[s]      | {runtime}")
+    print("======================================\n")
+
+    client.close()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Merge (dask/cudf) on LocalCUDACluster benchmark")
+    parser.add_argument(
+        "-d",
+        "--devs",
+        default="0,1,2,3",
+        type=str,
+        help='GPU devices to use (default "0, 1, 2, 3").',
+    )
+    parser.add_argument(
+        "-p",
+        "--protocol",
+        choices=["tcp", "ucx"],
+        default="tcp",
+        type=str,
+        help="The communication protocol to use.",
+    )
+    parser.add_argument("--no-rmm-pool", action="store_true", help="Disable the RMM memory pool")
+    parser.add_argument(
+        "--profile",
+        metavar="PATH",
+        default=None,
+        type=str,
+        help="Write dask profile report (E.g. dask-report.html)",
+    )
+    parser.add_argument(
+        "--data-path", type=str, help="Raw dataset path.",
+    )
+    parser.add_argument("--out-path", type=str, help="Root output path.")
+    parser.add_argument(
+        "--dask-workspace", default=None, type=str, help="Dask workspace path.",
+    )
+    parser.add_argument(
+        "-s", "--splits", default=24, type=int, help="Number of splits to shuffle each partition"
+    )
+    parser.add_argument(
+        "--part-mem-frac",
+        default=0.162,
+        type=float,
+        help="Fraction of device memory for each partition",
+    )
+    parser.add_argument(
+        "-f", "--freq-limit", default=0, type=int, help="Frequency limit on cat encodings."
+    )
+    parser.add_argument(
+        "--device-limit-frac",
+        default=0.8,
+        type=float,
+        help="Fractional device-memory limit (per worker).",
+    )
+    parser.add_argument(
+        "--device-pool-frac",
+        default=0.8,
+        type=float,
+        help="Fractional rmm pool size (per worker).",
+    )
+    parser.add_argument(
+        "--worker-shuffle", action="store_true", help="Perform followup shuffle on each worker."
+    )
+    parser.add_argument(
+        "--cat-names", default=None, type=str, help="List of categorical column names."
+    )
+    parser.add_argument(
+        "--cat-cache",
+        default=None,
+        type=str,
+        help='Where to cache each category (Ex "device, host, disk").',
+    )
+    parser.add_argument(
+        "--cat-splits",
+        default=None,
+        type=str,
+        help='How many splits to use for each category (Ex "8, 4, 2, 1").',
+    )
+    parser.add_argument(
+        "--cont-names", default=None, type=str, help="List of continuous column names."
+    )
+    args = parser.parse_args()
+    args.n_workers = len(args.devs.split(","))
+    return args
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/examples/dask-nvtabular-criteo-benchmark.py
+++ b/examples/dask-nvtabular-criteo-benchmark.py
@@ -6,10 +6,10 @@ import time
 
 import cudf
 import rmm
+from dask.distributed import Client, performance_report
 from dask_cuda import LocalCUDACluster
 
 import nvtabular.ops as ops
-from dask.distributed import Client, performance_report
 from nvtabular import DaskDataset, Workflow
 
 

--- a/examples/dask-nvtabular-criteo-benchmark.py
+++ b/examples/dask-nvtabular-criteo-benchmark.py
@@ -6,10 +6,10 @@ import time
 
 import cudf
 import rmm
+from dask_cuda import LocalCUDACluster
 
 import nvtabular.ops as ops
 from dask.distributed import Client, performance_report
-from dask_cuda import LocalCUDACluster
 from nvtabular import DaskDataset, Workflow
 
 
@@ -117,7 +117,11 @@ def main(args):
     processor.add_feature([ops.ZeroFill(), ops.LogOp()])
     processor.add_preprocess(
         ops.Categorify(
-            out_path=out_path, split_out=split_out, cat_cache=cat_cache, freq_threshold=freq_limit,
+            out_path=out_path,
+            split_out=split_out,
+            cat_cache=cat_cache,
+            freq_threshold=freq_limit,
+            on_host=(args.n_workers < 4),
         )
     )
     processor.finalize()

--- a/examples/dask-nvtabular-criteo-benchmark.py
+++ b/examples/dask-nvtabular-criteo-benchmark.py
@@ -44,24 +44,14 @@ def main(args):
         if args.cat_names is None:
             # Using Criteo... Use more hash partitions for
             # known high-cardinality columns
-            if args.n_workers >= 4:
-                split_out["C20"] = 8
-                split_out["C1"] = 8
-                split_out["C22"] = 4
-                split_out["C10"] = 4
-                split_out["C21"] = 2
-                split_out["C11"] = 2
-                split_out["C23"] = 2
-                split_out["C12"] = 2
-            else:
-                split_out["C20"] = 8
-                split_out["C1"] = 8
-                split_out["C22"] = 4
-                split_out["C10"] = 4
-                split_out["C21"] = 2
-                split_out["C11"] = 2
-                split_out["C23"] = 2
-                split_out["C12"] = 2
+            split_out["C20"] = 8
+            split_out["C1"] = 8
+            split_out["C22"] = 4
+            split_out["C10"] = 4
+            split_out["C21"] = 2
+            split_out["C11"] = 2
+            split_out["C23"] = 2
+            split_out["C12"] = 2
 
     # Specify categorical caching location
     cat_cache = None

--- a/examples/dask-nvtabular-criteo-benchmark.py
+++ b/examples/dask-nvtabular-criteo-benchmark.py
@@ -5,7 +5,7 @@ import os
 import time
 
 import cudf
-import rmm
+import numba.cuda as cuda
 from dask.distributed import Client, performance_report
 from dask_cuda import LocalCUDACluster
 
@@ -79,7 +79,7 @@ def main(args):
                 cat_cache["C10"] = "host"
 
     # Use total device size to calculate args.device_limit_frac
-    device_size = rmm.get_info().total
+    device_size = cuda.current_context().get_memory_info()[1]
     device_limit = int(args.device_limit_frac * device_size)
     device_pool_size = int(args.device_pool_frac * device_size)
     part_size = int(args.part_mem_frac * device_size)

--- a/examples/dask-nvtabular-criteo-benchmark.py
+++ b/examples/dask-nvtabular-criteo-benchmark.py
@@ -6,10 +6,10 @@ import time
 
 import cudf
 import rmm
-from dask.distributed import Client, performance_report
 from dask_cuda import LocalCUDACluster
 
 import nvtabular.ops as ops
+from dask.distributed import Client, performance_report
 from nvtabular import DaskDataset, Workflow
 
 

--- a/examples/dask-nvtabular-criteo-benchmark.py
+++ b/examples/dask-nvtabular-criteo-benchmark.py
@@ -121,7 +121,7 @@ def main(args):
             split_out=split_out,
             cat_cache=cat_cache,
             freq_threshold=freq_limit,
-            on_host=(args.n_workers < 4),
+            on_host=args.cat_on_host,
         )
     )
     processor.finalize()
@@ -229,6 +229,11 @@ def parse_args():
         default=None,
         type=str,
         help='Where to cache each category (Ex "device, host, disk").',
+    )
+    parser.add_argument(
+        "--cat-on-host",
+        action="store_true",
+        help="Whether to move categorical data to host between tasks.",
     )
     parser.add_argument(
         "--cat-splits",

--- a/nvtabular/__init__.py
+++ b/nvtabular/__init__.py
@@ -20,6 +20,7 @@ from .dask import DaskDataset
 
 Workflow = workflow.Workflow
 dataset = io.GPUDatasetIterator
+dask_dataset = DaskDataset  # Avoiding flake8 error
 
 
 __all__ = ["Workflow", "dataset"]

--- a/nvtabular/dask/__init__.py
+++ b/nvtabular/dask/__init__.py
@@ -15,6 +15,6 @@
 #
 
 
-import io
+from .io import DaskDataset
 
-DaskDataset = io.DaskDataset
+dask_dataset = DaskDataset  # Avoiding flake8 complaint

--- a/nvtabular/dask/__init__.py
+++ b/nvtabular/dask/__init__.py
@@ -14,4 +14,7 @@
 # limitations under the License.
 #
 
-from .io import DaskDataset
+
+import io
+
+DaskDataset = io.DaskDataset

--- a/nvtabular/dask/__init__.py
+++ b/nvtabular/dask/__init__.py
@@ -13,16 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import warnings
 
-from . import io, workflow
-from .dask import DaskDataset
-
-Workflow = workflow.Workflow
-dataset = io.GPUDatasetIterator
-
-
-__all__ = ["Workflow", "dataset"]
-
-# cudf warns about column ordering with dlpack methods, ignore it
-warnings.filterwarnings("ignore", module="cudf.io.dlpack")
+from .io import DaskDataset

--- a/nvtabular/dask/categorify.py
+++ b/nvtabular/dask/categorify.py
@@ -1,0 +1,219 @@
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from io import BytesIO
+from operator import getitem
+
+import cudf
+from cudf._lib.nvtx import annotate
+from fsspec.core import get_fs_token_paths
+
+from dask.base import tokenize
+from dask.dataframe.core import _concat
+from dask.distributed import get_worker
+from dask.highlevelgraph import HighLevelGraph
+
+try:
+    import cupy as cp
+except ImportError:
+    import numpy as cp
+
+
+class CategoryCache:
+    def __init__(self):
+        self.cat_cache = {}
+
+    @annotate("get_categories", color="green", domain="nvt_python")
+    def get_categories(self, col, path, cache="disk"):
+        table = self.cat_cache.get(col, None)
+        if table and not isinstance(table, cudf.DataFrame):
+            df = cudf.io.read_parquet(table, index=False, columns=[col])
+            df.index.name = "labels"
+            df.reset_index(drop=False, inplace=True)
+            return df
+
+        if table is None:
+            if cache in ("device", "disk"):
+                table = cudf.io.read_parquet(path, index=False, columns=[col])
+            elif cache == "host":
+                with open(path, "rb") as f:
+                    self.cat_cache[col] = BytesIO(f.read())
+                table = cudf.io.read_parquet(self.cat_cache[col], index=False, columns=[col])
+            table.index.name = "labels"
+            table.reset_index(drop=False, inplace=True)
+            if cache == "device":
+                self.cat_cache[col] = table.copy(deep=False)
+        return table
+
+
+@annotate("cat_level_1", color="green", domain="nvt_python")
+def _cat_level_1(gdf, columns, split_out):
+    # First level of "catigorify"
+    gdf["_count"] = cp.ones(len(gdf), dtype="int32")
+    output = {}
+    k = 0
+    for i, col in enumerate(columns):
+        gb = gdf[[col, "_count"]].groupby(col, dropna=False).count()
+        gb.reset_index(drop=False, inplace=True)
+        for j, split in enumerate(gb.partition_by_hash([col], split_out[col], keep_index=False)):
+            output[k] = split
+            k += 1
+        gdf.drop(columns=[col], inplace=True)
+        del gb
+    del gdf
+    return output
+
+
+@annotate("cat_level_2", color="green", domain="nvt_python")
+def _cat_level_2(dfs, col, freq_limit):
+    ignore_index = True
+    gb = _concat(dfs, ignore_index).groupby(col, dropna=False).count()
+    gb.reset_index(drop=False, inplace=True)
+    if freq_limit:
+        gb = gb[gb["_count"] >= freq_limit]
+    return gb[[col]]
+
+
+@annotate("cat_level_3", color="green", domain="nvt_python")
+def _cat_level_3(dfs, base_path, col):
+    ignore_index = True
+    df = _concat(dfs, ignore_index,)
+    rel_path = "unique.%s.parquet" % (col)
+    path = "/".join([base_path, rel_path])
+    if len(df):
+        # Make sure first category is Null
+        df = df.sort_values(col, na_position="first")
+        if not df[col]._column.has_nulls:
+            df = cudf.DataFrame({col: _concat([cudf.Series([None]), df[col]], ignore_index,)})
+        df.to_parquet(path, write_index=False, compression=None)
+    else:
+        df_null = cudf.DataFrame({col: [None]})
+        df_null[col] = df_null[col].astype(df[col].dtype)
+        df_null.to_parquet(path, write_index=False, compression=None)
+    del df
+    return path
+
+
+def _finish_labels(paths, cols):
+    return {col: paths[i] for i, col in enumerate(cols)}
+
+
+def _get_categories(ddf, cols, out_path, freq_limit, split_out):
+    if not cols:
+        return {}
+
+    # Update split_out
+    if split_out is None:
+        split_out = {c: 1 for c in cols}
+    elif isinstance(split_out, int):
+        split_out = {c: split_out for c in cols}
+    else:
+        for col in cols:
+            if col not in split_out:
+                split_out[col] = 1
+
+    # Make dedicated output directory for the categories
+    fs = get_fs_token_paths(out_path)[0]
+    out_path = fs.sep.join([out_path, "categories"])
+    fs.mkdirs(out_path, exist_ok=True)
+
+    dsk = {}
+    token = tokenize(ddf, cols, out_path, freq_limit, split_out)
+    level_1_name = "level_1-" + token
+    split_name = "split-" + token
+    level_2_name = "level_2-" + token
+    level_3_name = "level_3-" + token
+    finalize_labels_name = "categories-" + token
+    for p in range(ddf.npartitions):
+        dsk[(level_1_name, p)] = (
+            _cat_level_1,
+            (ddf._name, p),
+            cols,
+            split_out,
+        )
+        k = 0
+        for c, col in enumerate(cols):
+            for s in range(split_out[col]):
+                dsk[(split_name, p, c, s)] = (getitem, (level_1_name, p), k)
+                k += 1
+
+    for c, col in enumerate(cols):
+        for s in range(split_out[col]):
+            dsk[(level_2_name, c, s)] = (
+                _cat_level_2,
+                [(split_name, p, c, s) for p in range(ddf.npartitions)],
+                col,
+                freq_limit,
+            )
+
+        dsk[(level_3_name, c)] = (
+            _cat_level_3,
+            [(level_2_name, c, s) for s in range(split_out[col])],
+            out_path,
+            col,
+        )
+
+    dsk[finalize_labels_name] = (
+        _finish_labels,
+        [(level_3_name, c) for c, col in enumerate(cols)],
+        cols,
+    )
+    graph = HighLevelGraph.from_collections(finalize_labels_name, dsk, dependencies=[ddf])
+    return graph, finalize_labels_name
+
+
+def _get_cache():
+    try:
+        worker = get_worker()
+    except ValueError:
+        # This is a metadata operation, so there is no "worker"
+        # TODO: Handle metadata operations in a smarter way
+        return None
+    if not hasattr(worker, "cats_cache"):
+        worker.cats_cache = CategoryCache()
+    return worker.cats_cache
+
+
+def _encode(name, path, gdf, cat_cache, na_sentinel=-1, freq_threshold=0):
+    value = None
+    if path:
+        if cat_cache is not None:
+            cat_cache = cat_cache.get(name, "disk")
+            cache = _get_cache()
+            if cache:
+                value = cache.get_categories(name, path, cache=cat_cache)
+        else:
+            value = cudf.io.read_parquet(path, index=False, columns=[name])
+            value.index.name = "labels"
+            value.reset_index(drop=False, inplace=True)
+
+    vals = gdf[name].copy(deep=False)
+    if value is None:
+        value = cudf.DataFrame({name: [None]})
+        value[name] = value[name].astype(vals.dtype)
+        value.index.name = "labels"
+        value.reset_index(drop=False, inplace=True)
+
+    if freq_threshold > 0:
+        codes = cudf.DataFrame({name: vals.copy(), "order": cp.arange(len(vals))})
+        codes = codes.merge(value, on=name, how="left").sort_values("order")["labels"]
+        codes.fillna(na_sentinel, inplace=True)
+        return codes.values
+    else:
+        # Use `searchsorted` if we are using a "full" encoding
+        labels = value[name].searchsorted(vals, side="left", na_position="first")
+        labels[labels >= len(value[name])] = na_sentinel
+        return labels

--- a/nvtabular/dask/categorify.py
+++ b/nvtabular/dask/categorify.py
@@ -19,12 +19,11 @@ from operator import getitem
 
 import cudf
 from cudf._lib.nvtx import annotate
-from fsspec.core import get_fs_token_paths
-
 from dask.base import tokenize
 from dask.dataframe.core import _concat
 from dask.distributed import get_worker
 from dask.highlevelgraph import HighLevelGraph
+from fsspec.core import get_fs_token_paths
 
 try:
     import cupy as cp

--- a/nvtabular/dask/categorify.py
+++ b/nvtabular/dask/categorify.py
@@ -101,7 +101,7 @@ def _cat_level_2(dfs, col, freq_limit, on_host):
 @annotate("cat_level_3", color="green", domain="nvt_python")
 def _cat_level_3(dfs, base_path, col, on_host):
     ignore_index = True
-    df = _concat(dfs, ignore_index,)
+    df = _concat(dfs, ignore_index)
     if on_host:
         df = cudf.from_pandas(df)
     rel_path = "unique.%s.parquet" % (col)
@@ -110,7 +110,7 @@ def _cat_level_3(dfs, base_path, col, on_host):
         # Make sure first category is Null
         df = df.sort_values(col, na_position="first")
         if not df[col]._column.has_nulls:
-            df = cudf.DataFrame({col: _concat([cudf.Series([None]), df[col]], ignore_index,)})
+            df = cudf.DataFrame({col: _concat([cudf.Series([None]), df[col]], ignore_index)})
         df.to_parquet(path, write_index=False, compression=None)
     else:
         df_null = cudf.DataFrame({col: [None]})
@@ -151,13 +151,7 @@ def _get_categories(ddf, cols, out_path, freq_limit, split_out, on_host):
     level_3_name = "level_3-" + token
     finalize_labels_name = "categories-" + token
     for p in range(ddf.npartitions):
-        dsk[(level_1_name, p)] = (
-            _cat_level_1,
-            (ddf._name, p),
-            cols,
-            split_out,
-            on_host,
-        )
+        dsk[(level_1_name, p)] = (_cat_level_1, (ddf._name, p), cols, split_out, on_host)
         k = 0
         for c, col in enumerate(cols):
             for s in range(split_out[col]):

--- a/nvtabular/dask/io.py
+++ b/nvtabular/dask/io.py
@@ -127,15 +127,13 @@ def _worker_shuffle(processed_path, fs):
     for path, (pw, bio) in get_cache().pq_writer_cache.items():
         pw.close()
 
-        gdf = cudf.io.read_parquet(bio, index=False,)
+        gdf = cudf.io.read_parquet(bio, index=False)
         bio.close()
 
         gdf = _shuffle_gdf(gdf)
         rel_path = "shuffled.%s.parquet" % (guid())
         full_path = fs.sep.join([processed_path, rel_path])
-        gdf.to_parquet(
-            full_path, compression=None, index=False,
-        )
+        gdf.to_parquet(full_path, compression=None, index=False)
         paths.append(full_path)
     return paths
 
@@ -307,7 +305,7 @@ class ParquetDatasetEngine(DatasetEngine):
 
     def meta_empty(self, columns=None):
         path, _ = self.pieces[0]
-        return cudf.io.read_parquet(path, row_group=0, columns=columns, index=False,).iloc[:0]
+        return cudf.io.read_parquet(path, row_group=0, columns=columns, index=False).iloc[:0]
 
     def to_ddf(self, columns=None):
         pieces = self.pieces

--- a/nvtabular/dask/io.py
+++ b/nvtabular/dask/io.py
@@ -25,16 +25,15 @@ import pyarrow.parquet as pq
 import rmm
 from cudf._lib.nvtx import annotate
 from cudf.io.parquet import ParquetWriter
-from fsspec.core import get_fs_token_paths
-from fsspec.utils import stringify_path
-from pyarrow.compat import guid
-
 from dask.base import tokenize
 from dask.dataframe.core import new_dd_object
 from dask.dataframe.io.parquet.utils import _analyze_paths
 from dask.dataframe.utils import group_split_dispatch
 from dask.distributed import get_worker
 from dask.utils import natural_sort_key, parse_bytes
+from fsspec.core import get_fs_token_paths
+from fsspec.utils import stringify_path
+from pyarrow.compat import guid
 
 
 class WriterCache:

--- a/nvtabular/dask/io.py
+++ b/nvtabular/dask/io.py
@@ -20,9 +20,9 @@ from io import BytesIO
 
 import cudf
 import cupy
+import numba.cuda as cuda
 import numpy as np
 import pyarrow.parquet as pq
-import rmm
 from cudf._lib.nvtx import annotate
 from cudf.io.parquet import ParquetWriter
 from dask.base import tokenize
@@ -176,7 +176,7 @@ class DaskDataset:
                     "Using very large partitions sizes for Dask. "
                     "Memory-related errors are likely."
                 )
-            part_size = int(rmm.get_info().total * part_mem_fraction)
+            part_size = int(cuda.current_context().get_memory_info()[1] * part_mem_fraction)
 
         if isinstance(engine, str):
             if engine == "parquet":

--- a/nvtabular/dask/io.py
+++ b/nvtabular/dask/io.py
@@ -1,0 +1,321 @@
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import warnings
+from collections import defaultdict
+from io import BytesIO
+
+import cudf
+import cupy
+import numpy as np
+import pyarrow.parquet as pq
+import rmm
+from cudf._lib.nvtx import annotate
+from cudf.io.parquet import ParquetWriter
+from fsspec.core import get_fs_token_paths
+from fsspec.utils import stringify_path
+from pyarrow.compat import guid
+
+from dask.base import tokenize
+from dask.dataframe.core import new_dd_object
+from dask.dataframe.io.parquet.utils import _analyze_paths
+from dask.dataframe.utils import group_split_dispatch
+from dask.distributed import get_worker
+from dask.utils import natural_sort_key, parse_bytes
+
+
+class WriterCache:
+    def __init__(self):
+        self.pq_writer_cache = {}
+
+    def __del__(self):
+        for path, (pw, fpath) in self.pq_writer_cache.items():
+            pw.close()
+
+    def get_pq_writer(self, prefix, s, mem):
+        pw, fil = self.pq_writer_cache.get(prefix, (None, None))
+        if pw is None:
+            if mem:
+                fil = BytesIO()
+                pw = ParquetWriter(fil, compression=None)
+                self.pq_writer_cache[prefix] = (pw, fil)
+            else:
+                outfile_id = guid() + ".parquet"
+                full_path = ".".join([prefix, outfile_id])
+                pw = ParquetWriter(full_path, compression=None)
+                self.pq_writer_cache[prefix] = (pw, full_path)
+        return pw
+
+
+def get_cache():
+    try:
+        worker = get_worker()
+    except ValueError:
+        # This is a metadata operation, so there is no "worker"
+        # TODO: Handle metadata operations in a smarter way
+        return None
+    if not hasattr(worker, "pw_cache"):
+        worker.pw_cache = WriterCache()
+    return worker.pw_cache
+
+
+def clean_pw_cache():
+    worker = get_worker()
+    if hasattr(worker, "pw_cache"):
+        del worker.pw_cache
+    return
+
+
+def _write_metadata(meta_list):
+    # TODO: Write _metadata file here (need to collect metadata)
+    return meta_list
+
+
+def _shuffle_gdf(gdf, gdf_size=None):
+    gdf_size = gdf_size or len(gdf)
+    arr = cupy.arange(gdf_size)
+    cupy.random.shuffle(arr)
+    return gdf.iloc[arr]
+
+
+@annotate("write_output_partition", color="green", domain="nvt_python")
+def _write_output_partition(gdf, processed_path, shuffle, nsplits, fs):
+    gdf_size = len(gdf)
+    if shuffle == "full":
+        # Dont need a real sort if we are doing in memory later
+        typ = np.min_scalar_type(nsplits * 2)
+        ind = cupy.random.choice(cupy.arange(nsplits, dtype=typ), gdf_size)
+        result = group_split_dispatch(gdf, ind, nsplits, ignore_index=True)
+        del ind
+        del gdf
+        # Write each split to a separate file
+        for s, df in result.items():
+            prefix = fs.sep.join([processed_path, "split." + str(s)])
+            pw = get_cache().get_pq_writer(prefix, s, mem=True)
+            pw.write_table(df)
+    else:
+        # We should do a real sort here
+        if shuffle == "partial":
+            gdf = _shuffle_gdf(gdf, gdf_size=gdf_size)
+        splits = list(range(0, gdf_size, int(gdf_size / nsplits)))
+        if splits[-1] < gdf_size:
+            splits.append(gdf_size)
+        # Write each split to a separate file
+        for s in range(0, len(splits) - 1):
+            prefix = fs.sep.join([processed_path, "split." + str(s)])
+            pw = get_cache().get_pq_writer(prefix, s, mem=False)
+            pw.write_table(gdf.iloc[splits[s] : splits[s + 1]])
+    return gdf_size  # TODO: Make this metadata
+
+
+@annotate("worker_shuffle", color="green", domain="nvt_python")
+def _worker_shuffle(processed_path, fs):
+    paths = []
+    for path, (pw, bio) in get_cache().pq_writer_cache.items():
+        pw.close()
+
+        gdf = cudf.io.read_parquet(bio, index=False,)
+        bio.close()
+
+        gdf = _shuffle_gdf(gdf)
+        rel_path = "shuffled.%s.parquet" % (guid())
+        full_path = fs.sep.join([processed_path, rel_path])
+        gdf.to_parquet(
+            full_path, compression=None, index=False,
+        )
+        paths.append(full_path)
+    return paths
+
+
+class DaskDataset:
+    """ DaskDataset Class
+        Converts a dataset into a dask_cudf DataFrame on demand
+
+    Parameters
+    -----------
+    path : str or list of str
+        Dataset path (or list of paths). If string, should specify
+        a specific file or directory path.
+    engine : str or DatasetEngine
+        DatasetEngine object or string identifier of engine. Current
+        string options include: ("parquet").
+    part_size : str or int
+        Desired size (in bytes) of each Dask partition.
+        If None, part_mem_fraction will be used to calculate the
+        partition size.  Note that the underlying engine may allow
+        other custom kwargs to override this argument.
+    part_mem_fraction : float (default 0.125)
+        Fractional size of desired dask partitions (relative
+        to GPU memory capacity). Ignored if part_size is passed
+        directly. Note that the underlying engine may allow other
+        custom kwargs to override this argument.
+    **kwargs :
+        Other arguments to be passed to DatasetEngine.
+    """
+
+    def __init__(self, path, engine, part_size=None, part_mem_fraction=0.125, **kwargs):
+
+        if part_size:
+            # If a specific partition size is given, use it directly
+            part_size = parse_bytes(part_size)
+        else:
+            # If a fractional partition size is given, calculate part_size
+            assert part_mem_fraction > 0.0 and part_mem_fraction < 1.0
+            if part_mem_fraction > 0.25:
+                warnings.warn(
+                    "Using very large partitions sizes for Dask. "
+                    "Memory-related errors are likely."
+                )
+            part_size = int(rmm.get_info().total * part_mem_fraction)
+
+        if isinstance(engine, str):
+            if engine == "parquet":
+                self.engine = ParquetDatasetEngine(path, part_size, **kwargs)
+            else:
+                raise ValueError("Only parquet supported for now")
+        else:
+            self.engine = engine(path, part_size, **kwargs)
+
+    def meta_empty(self, columns=None):
+        return self.engine.meta_empty(columns=columns)
+
+    def to_ddf(self, columns=None):
+        return self.engine.to_ddf(columns=columns)
+
+
+class DatasetEngine:
+    """ DaskDataset Class
+        Converts dataset `pieces` to a dask_cudf DataFrame
+    """
+
+    def __init__(self, path, part_size):
+        if hasattr(path, "name"):
+            path = stringify_path(path)
+        fs, _, paths = get_fs_token_paths(path, mode="rb")
+        self.fs = fs
+        self.paths = sorted(paths, key=natural_sort_key)
+        self.part_size = part_size
+
+    def meta_empty(self, columns=None):
+        raise NotImplementedError(""" Return an empty cudf.DataFrame with the correct schema """)
+
+    def to_ddf(self, columns=None):
+        raise NotImplementedError(""" Return a dask_cudf.DataFrame """)
+
+
+class ParquetDatasetEngine(DatasetEngine):
+    def __init__(self, *args, row_groups_per_part=None):
+        super().__init__(*args)
+        self._metadata, self._base = self.get_metadata()
+        self._pieces = None
+        if row_groups_per_part is None:
+            # TODO: Use `total_byte_size` metadata if/when we figure out how to
+            #       correct for apparent dict encoding of cat/string columns.
+            path0 = self.fs.sep.join([self._base, self._metadata.row_group(0).column(0).file_path])
+            rg_byte_size_0 = (
+                cudf.io.read_parquet(path0, row_group=0).memory_usage(deep=True, index=True).sum()
+            )
+            self.row_groups_per_part = int(self.part_size / rg_byte_size_0)
+        else:
+            self.row_groups_per_part = int(row_groups_per_part)
+        assert self.row_groups_per_part > 0
+
+    @property
+    def pieces(self):
+        if self._pieces is None:
+            self._pieces = self._get_pieces(self._metadata, self._base)
+        return self._pieces
+
+    def get_metadata(self):
+        paths = self.paths
+        fs = self.fs
+        if len(paths) > 1:
+            # This is a list of files
+            dataset = pq.ParquetDataset(paths, filesystem=fs)
+            base, fns = _analyze_paths(paths, fs)
+        elif fs.isdir(paths[0]):
+            # This is a directory
+            dataset = pq.ParquetDataset(paths[0], filesystem=fs)
+            allpaths = fs.glob(paths[0] + fs.sep + "*")
+            base, fns = _analyze_paths(allpaths, fs)
+        else:
+            # This is a single file
+            dataset = pq.ParquetDataset(paths[0], filesystem=fs)
+            base = paths[0]
+            fns = [None]
+
+        metadata = None
+        if dataset.metadata:
+            # We have a metadata file
+            return dataset.metadata, base
+        else:
+            # Collect proper metadata manually
+            metadata = None
+            for piece, fn in zip(dataset.pieces, fns):
+                md = piece.get_metadata()
+                if fn:
+                    md.set_file_path(fn)
+                if metadata:
+                    metadata.append_row_groups(md)
+                else:
+                    metadata = md
+            return metadata, base
+
+    @annotate("get_pieces", color="green", domain="nvt_python")
+    def _get_pieces(self, metadata, data_path):
+        # get the number of row groups per file
+        file_row_groups = defaultdict(int)
+        for rg in range(metadata.num_row_groups):
+            fpath = metadata.row_group(rg).column(0).file_path
+            if fpath is None:
+                raise ValueError("metadata is missing file_path string.")
+            file_row_groups[fpath] += 1
+        # create pieces from each file, limiting the number of row_groups in each piece
+        pieces = []
+        for filename, row_group_count in file_row_groups.items():
+            row_groups = range(row_group_count)
+            for i in range(0, row_group_count, self.row_groups_per_part):
+                rg_list = list(row_groups[i : i + self.row_groups_per_part])
+                full_path = self.fs.sep.join([data_path, filename])
+                pieces.append((full_path, rg_list))
+        return pieces
+
+    @staticmethod
+    @annotate("read_piece", color="green", domain="nvt_python")
+    def read_piece(piece, columns):
+        path, row_groups = piece
+        return cudf.io.read_parquet(
+            path,
+            row_group=row_groups[0],
+            row_group_count=len(row_groups),
+            columns=columns,
+            index=False,
+        )
+
+    def meta_empty(self, columns=None):
+        path, _ = self.pieces[0]
+        return cudf.io.read_parquet(path, row_group=0, columns=columns, index=False,).iloc[:0]
+
+    def to_ddf(self, columns=None):
+        pieces = self.pieces
+        name = "parquet-to-ddf-" + tokenize(pieces, columns)
+        dsk = {
+            (name, p): (ParquetDatasetEngine.read_piece, piece, columns)
+            for p, piece in enumerate(pieces)
+        }
+        meta = self.meta_empty(columns=columns)
+        divisions = [None] * (len(pieces) + 1)
+        return new_dd_object(dsk, name, meta, divisions)

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -25,6 +25,7 @@ from nvtabular.dask.categorify import _encode, _get_categories
 from nvtabular.encoder import DLLabelEncoder
 from nvtabular.groupby import GroupByMomentsCal
 
+
 CONT = "continuous"
 CAT = "categorical"
 ALL = "all"

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -25,7 +25,6 @@ from nvtabular.dask.categorify import _encode, _get_categories
 from nvtabular.encoder import DLLabelEncoder
 from nvtabular.groupby import GroupByMomentsCal
 
-
 CONT = "continuous"
 CAT = "categorical"
 ALL = "all"

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -169,9 +169,7 @@ class StatOperator(Operator):
     def __init__(self, columns=None):
         super(StatOperator, self).__init__(columns)
 
-    def read_itr(
-        self, gdf: cudf.DataFrame, columns_ctx: dict, input_cols, target_cols="base",
-    ):
+    def read_itr(self, gdf: cudf.DataFrame, columns_ctx: dict, input_cols, target_cols="base"):
         raise NotImplementedError(
             """The operation to conduct on the dataframe to observe the desired statistics."""
         )
@@ -229,9 +227,7 @@ class MinMax(StatOperator):
         self.maxs = maxs if maxs is not None else {}
 
     @annotate("MinMax_op", color="green", domain="nvt_python")
-    def apply_op(
-        self, gdf: cudf.DataFrame, columns_ctx: dict, input_cols, target_cols="base",
-    ):
+    def apply_op(self, gdf: cudf.DataFrame, columns_ctx: dict, input_cols, target_cols="base"):
         """ Iteration level Min Max collection, a chunk at a time
         """
         cols = self.get_columns(columns_ctx, input_cols, target_cols)
@@ -320,9 +316,7 @@ class Moments(StatOperator):
         self.stds = stds if stds is not None else {}
 
     @annotate("Moments_op", color="green", domain="nvt_python")
-    def apply_op(
-        self, gdf: cudf.DataFrame, columns_ctx: dict, input_cols, target_cols="base",
-    ):
+    def apply_op(self, gdf: cudf.DataFrame, columns_ctx: dict, input_cols, target_cols="base"):
         """ Iteration-level moment algorithm (mean/std).
         """
         cols = self.get_columns(columns_ctx, input_cols, target_cols)
@@ -422,9 +416,7 @@ class Median(StatOperator):
         self.medians = medians if medians is not None else {}
 
     @annotate("Median_op", color="green", domain="nvt_python")
-    def apply_op(
-        self, gdf: cudf.DataFrame, columns_ctx: dict, input_cols, target_cols="base",
-    ):
+    def apply_op(self, gdf: cudf.DataFrame, columns_ctx: dict, input_cols, target_cols="base"):
         """ Iteration-level median algorithm.
         """
         cols = self.get_columns(columns_ctx, input_cols, target_cols)
@@ -535,9 +527,7 @@ class Encoder(StatOperator):
         self.on_host = on_host
 
     @annotate("Encoder_op", color="green", domain="nvt_python")
-    def apply_op(
-        self, gdf: cudf.DataFrame, columns_ctx: dict, input_cols, target_cols="base",
-    ):
+    def apply_op(self, gdf: cudf.DataFrame, columns_ctx: dict, input_cols, target_cols="base"):
         """ Iteration-level categorical encoder update.
         """
         cols = self.get_columns(columns_ctx, input_cols, target_cols)
@@ -759,9 +749,7 @@ class FillMissing(DFOperator):
     default_in = CONT
     default_out = CONT
 
-    def __init__(
-        self, fill_val=0, columns=None, preprocessing=True, replace=True,
-    ):
+    def __init__(self, fill_val=0, columns=None, preprocessing=True, replace=True):
         super().__init__(columns=columns, preprocessing=preprocessing, replace=replace)
         self.fill_val = fill_val
 

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -1156,6 +1156,7 @@ class Categorify(DFOperator):
                 out_path=self.out_path,
                 split_out=self.split_out,
                 on_host=self.on_host,
+                na_sentinel=self.na_sentinel,
             )
         ]
 

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -19,8 +19,8 @@ import os
 import cudf
 import numpy as np
 from cudf._lib.nvtx import annotate
-
 from dask.delayed import Delayed
+
 from nvtabular.dask.categorify import _encode, _get_categories
 from nvtabular.encoder import DLLabelEncoder
 from nvtabular.groupby import GroupByMomentsCal

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -1156,7 +1156,6 @@ class Categorify(DFOperator):
                 out_path=self.out_path,
                 split_out=self.split_out,
                 on_host=self.on_host,
-                na_sentinel=self.na_sentinel,
             )
         ]
 

--- a/nvtabular/tf_dataloader.py
+++ b/nvtabular/tf_dataloader.py
@@ -10,7 +10,7 @@ from packaging import version
 from tensorflow.python.feature_column import feature_column_v2 as fc
 
 from .io import GPUDatasetIterator
-from .workflow import Workflow, _shuffle_part
+from .workflow import BaseWorkflow, _shuffle_part
 
 free_gpu_mem_mb = rmm.get_info().free / (1024 ** 2)
 tf_mem_size = os.environ.get("TF_MEMORY_ALLOCATION", 0.5)
@@ -254,7 +254,7 @@ class KerasSequenceDataset(tf.keras.utils.Sequence):
     Each chunk read by the iterator will be transformed
     via `workflow.apply_ops`.
     """
-        if not isinstance(workflow, Workflow):
+        if not isinstance(workflow, BaseWorkflow):
             raise TypeError("Expected NVTabular Workflow, found type {}".format(type(workflow)))
 
         self.workflows.append(workflow)

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -26,8 +26,13 @@ from fsspec.core import get_fs_token_paths
 from dask.base import tokenize
 from dask.delayed import Delayed
 from dask.highlevelgraph import HighLevelGraph
-from nvtabular.dask.io import (DaskDataset, _worker_shuffle, _write_metadata,
-                               _write_output_partition, clean_pw_cache)
+from nvtabular.dask.io import (
+    DaskDataset,
+    _worker_shuffle,
+    _write_metadata,
+    _write_output_partition,
+    clean_pw_cache,
+)
 from nvtabular.ds_writer import DatasetWriter
 from nvtabular.encoder import DLLabelEncoder
 from nvtabular.io import HugeCTR, Shuffler

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -21,12 +21,12 @@ import warnings
 import cudf
 import yaml
 from cudf._lib.nvtx import annotate
-from fsspec.core import get_fs_token_paths
-
-import nvtabular.dask.io as dask_io
 from dask.base import tokenize
 from dask.delayed import Delayed
 from dask.highlevelgraph import HighLevelGraph
+from fsspec.core import get_fs_token_paths
+
+import nvtabular.dask.io as dask_io
 from nvtabular.ds_writer import DatasetWriter
 from nvtabular.encoder import DLLabelEncoder
 from nvtabular.io import HugeCTR, Shuffler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ line-length = 100
 line_length = 100
 balanced_wrapping = true
 indent = "    "
-known_third_party = ["cudf", "cupy", "dask", "dask_cudf", "numpy", "pytest", "torch", "rmm", "tensorflow"]
+known_third_party = ["cudf", "cupy", "dask", "dask_cuda", "dask_cudf", "numpy", "pytest", "torch", "rmm", "tensorflow"]
 skip = ["build",".eggs", "examples/criteo_benchmark.py", "examples/dataloader_bench.py"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ line-length = 100
 line_length = 100
 balanced_wrapping = true
 indent = "    "
-known_third_party = ["cudf", "cupy", "dask", "numpy", "pytest", "torch", "rmm", "tensorflow"]
+known_third_party = ["cudf", "cupy", "dask", "dask_cudf", "numpy", "pytest", "torch", "rmm", "tensorflow"]
 skip = ["build",".eggs", "examples/criteo_benchmark.py", "examples/dataloader_bench.py"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ line-length = 100
 line_length = 100
 balanced_wrapping = true
 indent = "    "
-known_third_party = ["cudf", "cupy", "dask", "dask_cudf", "numpy", "pytest", "torch", "rmm", "tensorflow"]
+known_third_party = ["cudf", "cupy", "dask", "dask.distributed", "dask_cudf", "numpy", "pytest", "torch", "rmm", "tensorflow"]
 skip = ["build",".eggs", "examples/criteo_benchmark.py", "examples/dataloader_bench.py"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ line-length = 100
 line_length = 100
 balanced_wrapping = true
 indent = "    "
-known_third_party = ["cudf", "cupy", "dask", "dask.distributed", "dask_cudf", "numpy", "pytest", "torch", "rmm", "tensorflow"]
+known_third_party = ["cudf", "cupy", "dask", "dask_cudf", "numpy", "pytest", "torch", "rmm", "tensorflow"]
 skip = ["build",".eggs", "examples/criteo_benchmark.py", "examples/dataloader_bench.py"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ line-length = 100
 line_length = 100
 balanced_wrapping = true
 indent = "    "
-known_third_party = ["cudf", "cupy", "dask", "dask_cuda", "dask_cudf", "numpy", "pytest", "torch", "rmm", "tensorflow"]
+known_third_party = ["cudf", "cupy", "dask", "dask_cuda", "dask_cudf", "numba", "numpy", "pytest", "torch", "rmm", "tensorflow"]
 skip = ["build",".eggs", "examples/criteo_benchmark.py", "examples/dataloader_bench.py"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ line-length = 100
 line_length = 100
 balanced_wrapping = true
 indent = "    "
-known_third_party = ["cudf", "cupy", "numpy", "pytest", "torch", "rmm", "tensorflow"]
+known_third_party = ["cudf", "cupy", "dask", "numpy", "pytest", "torch", "rmm", "tensorflow"]
 skip = ["build",".eggs", "examples/criteo_benchmark.py", "examples/dataloader_bench.py"]
 

--- a/tests/unit/test_dask_nvt.py
+++ b/tests/unit/test_dask_nvt.py
@@ -71,7 +71,7 @@ def test_dask_workflow_api_dlrm(dask_cluster, tmpdir, datasets, freq_threshold, 
     label_name = ["label"]
 
     processor = Workflow(
-        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name,
+        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name
     )
 
     processor.add_feature([ops.ZeroFill(), ops.LogOp()])
@@ -126,7 +126,7 @@ def test_dask_minmax_dummyop(dask_cluster, tmpdir, datasets, engine):
             return _dummy_op_logic(*args, _id=self._id, **kwargs)
 
     processor = Workflow(
-        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name,
+        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name
     )
     processor.add_preprocess(DummyOp())
     processor.finalize()
@@ -163,7 +163,7 @@ def test_dask_median_dummyop(dask_cluster, tmpdir, datasets, engine):
             return _dummy_op_logic(*args, _id=self._id, **kwargs)
 
     processor = Workflow(
-        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name,
+        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name
     )
     processor.add_preprocess(DummyOp())
     processor.finalize()
@@ -193,7 +193,7 @@ def test_dask_normalize(dask_cluster, tmpdir, datasets, engine):
     label_name = ["label"]
 
     processor = Workflow(
-        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name,
+        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name
     )
     processor.add_preprocess(ops.Normalize())
     processor.finalize()

--- a/tests/unit/test_dask_nvt.py
+++ b/tests/unit/test_dask_nvt.py
@@ -19,11 +19,11 @@ import math
 
 import cudf
 import cupy
+import dask_cudf
 import pytest
 from dask.dataframe import assert_eq
 from dask.distributed import Client, LocalCluster
 
-import dask_cudf
 import nvtabular.ops as ops
 from nvtabular import DaskDataset, Workflow
 from tests.conftest import mycols_pq

--- a/tests/unit/test_dask_nvt.py
+++ b/tests/unit/test_dask_nvt.py
@@ -20,11 +20,11 @@ import math
 import cudf
 import cupy
 import pytest
+from dask.dataframe import assert_eq
+from dask.distributed import Client, LocalCluster
 
 import dask_cudf
 import nvtabular.ops as ops
-from dask.dataframe import assert_eq
-from dask.distributed import Client, LocalCluster
 from nvtabular import DaskDataset, Workflow
 from tests.conftest import mycols_pq
 

--- a/tests/unit/test_dask_nvt.py
+++ b/tests/unit/test_dask_nvt.py
@@ -1,0 +1,217 @@
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import glob
+import math
+
+import cudf
+import cupy
+import pytest
+
+import dask_cudf
+import nvtabular.ops as ops
+from dask.dataframe import assert_eq
+from dask.distributed import Client, LocalCluster
+from nvtabular import DaskDataset, Workflow
+from tests.conftest import mycols_pq
+
+# LocalCluster Client Fixture
+client = None
+
+
+@pytest.fixture(scope="module")
+def dask_cluster(request):
+    global client
+    client = Client(LocalCluster(n_workers=2))
+
+    def client_close():
+        global client
+        client.close()
+
+    request.addfinalizer(client_close)
+
+
+# Dummy operator logic to test stats
+# TODO: Possibly add public API to add
+#       standalone Stat Ops
+def _dummy_op_logic(gdf, target_columns, _id="dummy", **kwargs):
+    cont_names = target_columns
+    if not cont_names:
+        return gdf
+    new_gdf = gdf[cont_names]
+    new_cols = [f"{col}_{_id}" for col in new_gdf.columns]
+    new_gdf.columns = new_cols
+    return new_gdf
+
+
+@pytest.mark.parametrize("engine", ["parquet"])
+@pytest.mark.parametrize("freq_threshold", [0, 5])
+def test_dask_workflow_api_dlrm(dask_cluster, tmpdir, datasets, freq_threshold, engine):
+
+    paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
+    df1 = cudf.read_parquet(paths[0])[mycols_pq]
+    df2 = cudf.read_parquet(paths[1])[mycols_pq]
+    df0 = cudf.concat([df1, df2], axis=0)
+
+    cat_names = ["name-cat", "name-string"]
+    cont_names = ["x", "y", "id"]
+    label_name = ["label"]
+
+    processor = Workflow(
+        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name,
+    )
+
+    processor.add_feature([ops.ZeroFill(), ops.LogOp()])
+    processor.add_preprocess(ops.Categorify(freq_threshold=freq_threshold, out_path=str(tmpdir)))
+    processor.finalize()
+
+    dataset = DaskDataset(paths, engine)
+    processor.apply(dataset, output_path=str(tmpdir))
+    result = processor.get_ddf().compute()
+
+    assert len(df0) == len(result)
+    assert result["x"].min() == 0.0
+    assert result["x"].isna().sum() == 0
+    assert result["y"].min() == 0.0
+    assert result["y"].isna().sum() == 0
+
+    # Check category counts
+    if freq_threshold == 0:
+        assert len(df0["name-cat"].unique()) == len(result["name-cat"].unique())
+        assert len(df0["name-string"].unique()) == len(result["name-string"].unique())
+
+        df0["_count"] = cupy.ones(len(df0))
+        result["_count"] = cupy.ones(len(result))
+        for col in ["name-cat", "name-string"]:
+            expect = df0.groupby(col, dropna=False).count()["_count"].sort_values("_count")
+            got = result.groupby(col, dropna=False).count()["_count"].sort_values("_count")
+            assert_eq(expect, got, check_index=False)
+
+    # Read back from disk
+    df_disk = dask_cudf.read_parquet("/".join([str(tmpdir), "processed"]), index=False).compute()
+    for col in df_disk:
+        assert_eq(result[col], df_disk[col])
+
+
+@pytest.mark.parametrize("engine", ["parquet"])
+def test_dask_minmax_dummyop(dask_cluster, tmpdir, datasets, engine):
+
+    paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
+    cat_names = ["name-cat", "name-string"]
+    cont_names = ["x", "y", "id"]
+    label_name = ["label"]
+
+    class DummyOp(ops.DFOperator):
+
+        default_in, default_out = "continuous", "continuous"
+
+        @property
+        def req_stats(self):
+            return [ops.MinMax()]
+
+        def op_logic(self, *args, **kwargs):
+            return _dummy_op_logic(*args, _id=self._id, **kwargs)
+
+    processor = Workflow(
+        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name,
+    )
+    processor.add_preprocess(DummyOp())
+    processor.finalize()
+
+    dataset = DaskDataset(paths, engine)
+    processor.apply(dataset)
+    result = processor.get_ddf().compute()
+
+    assert math.isclose(result.x.min(), processor.stats["mins"]["x"], rel_tol=1e-3)
+    assert math.isclose(result.y.min(), processor.stats["mins"]["y"], rel_tol=1e-3)
+    assert math.isclose(result.id.min(), processor.stats["mins"]["id"], rel_tol=1e-3)
+    assert math.isclose(result.x.max(), processor.stats["maxs"]["x"], rel_tol=1e-3)
+    assert math.isclose(result.y.max(), processor.stats["maxs"]["y"], rel_tol=1e-3)
+    assert math.isclose(result.id.max(), processor.stats["maxs"]["id"], rel_tol=1e-3)
+
+
+@pytest.mark.parametrize("engine", ["parquet"])
+def test_dask_median_dummyop(dask_cluster, tmpdir, datasets, engine):
+
+    paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
+    cat_names = ["name-cat", "name-string"]
+    cont_names = ["x", "y", "id"]
+    label_name = ["label"]
+
+    class DummyOp(ops.DFOperator):
+
+        default_in, default_out = "continuous", "continuous"
+
+        @property
+        def req_stats(self):
+            return [ops.Median()]
+
+        def op_logic(self, *args, **kwargs):
+            return _dummy_op_logic(*args, _id=self._id, **kwargs)
+
+    processor = Workflow(
+        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name,
+    )
+    processor.add_preprocess(DummyOp())
+    processor.finalize()
+
+    dataset = DaskDataset(paths, engine)
+    processor.apply(dataset)
+    result = processor.get_ddf().compute()
+
+    # TODO: Improve the accuracy! "tidigest" with crick could help,
+    #       but current version seems to have cupy/numpy problems here
+    medians = result[cont_names].quantile(q=0.5)
+    assert math.isclose(medians["x"], processor.stats["medians"]["x"], abs_tol=1e-1)
+    assert math.isclose(medians["y"], processor.stats["medians"]["y"], abs_tol=1e-1)
+    assert math.isclose(medians["id"], processor.stats["medians"]["id"], rel_tol=1e-2)
+
+
+@pytest.mark.parametrize("engine", ["parquet"])
+def test_dask_normalize(dask_cluster, tmpdir, datasets, engine):
+
+    paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
+    df1 = cudf.read_parquet(paths[0])[mycols_pq]
+    df2 = cudf.read_parquet(paths[1])[mycols_pq]
+    df0 = cudf.concat([df1, df2], axis=0)
+
+    cat_names = ["name-cat", "name-string"]
+    cont_names = ["x", "y", "id"]
+    label_name = ["label"]
+
+    processor = Workflow(
+        client=client, cat_names=cat_names, cont_names=cont_names, label_name=label_name,
+    )
+    processor.add_preprocess(ops.Normalize())
+    processor.finalize()
+
+    dataset = DaskDataset(paths, engine)
+    processor.apply(dataset)
+    result = processor.get_ddf().compute()
+
+    # Make sure we collected accurate statistics
+    means = df0[cont_names].mean()
+    stds = df0[cont_names].std()
+    counts = df0[cont_names].count()
+    for name in cont_names:
+        assert math.isclose(means[name], processor.stats["means"][name], rel_tol=1e-3)
+        assert math.isclose(stds[name], processor.stats["stds"][name], rel_tol=1e-3)
+        assert math.isclose(counts[name], processor.stats["counts"][name], rel_tol=1e-3)
+
+    # New (normalized) means should all be close to zero
+    new_means = result[cont_names].mean()
+    for name in cont_names:
+        assert new_means[name] < 1e-3


### PR DESCRIPTION
Note that this is a copy of recsys#136 (from the original nvtabular repo).  Here is the original PR summary:


This is an initial implementation of a `DaskWorkflow` (and necessary io/op componts) in `nvtabular`.  Feedback/complaints are very welcome :)

The current PR makes the following changes to the directory/file layout:
```
nvtabular/
    workflow.py # DaskWorkflow code added
    ops.py # Dask logic added to select operators
    dask/. # Dedicated module for dask-specific code
        __init__.py
        io.py # Includes DaskDataset implementations (replaces iterator approach in nvtabular)
        categorify.py # Specialized Dask code for categorical encodings
```
Note that the `dask/` directory is added for dask-specific code.

From the users perspective, the multi-GPU workflow is very similar.  However, a `client` object will need to be passed to `Workflow`, and a `DaskDataset` object will need to be passed to `apply` or `update_stats` (not an iterator object):

```python
import nvtabular as nvt
import nvtabular.ops as ops

client = <create dask cluster and client>

processor = nvt.Workflow(
    cat_names=cat_names,
    cont_names=cont_names,
    label_name=label_name,
    client = client,
)

processor.add_feature([ops.ZeroFill(columns=op_columns), ops.LogOp()])
processor.add_preprocess(ops.Normalize())
processor.add_preprocess(ops.Categorify(out_path=out_path))
processor.finalize()

dataset = nvt.DaskDataset(path, "parquet")
processor.update_stats(dataset, output_path=out_path)
```

Regarding `DaskDataset`:  Only the parquet-based "engine" for this class is currently implemented. The parquet engine is essentially a duplication of the `read_parquet` implementation used by `dask_cudf`/`dask.dataframe`.  However, since it drops certain filtering support and assumes the underlying reader can handle row-group ranges (which cudf **can** do), it is currently much more performant for our typical use case.  In the future, I would like this class to become a much thinner shim layer.

**TODO** (Likely in this PR):
- [x] Confirm general organization makes sense.  General consensus that dask integration should be nearly transparent to the user.  Therefore, we are on the right track here (although there is certainly room for improvement)
- [x] Implement proper shuffle/export
- [x] Implement host-memory caching
- [x] Improve `DaskWorkflow` testing
- [x] Add new criteo+Dask benchmark

**TODO** (Post PR):
- [ ] Support "online" apply (https://github.com/NVIDIA/NVTabular/issues/56)
- [ ] Add/Improve Ops
- [ ] Add CSV/ORC support (https://github.com/NVIDIA/NVTabular/issues/61 / https://github.com/NVIDIA/NVTabular/issues/50)
- [ ] Add `"_metadata"` write to output shuffle (see [cudf#5284](https://github.com/rapidsai/cudf/issues/5284))
- [ ] Expand testing (including saving and loading stats)
- [ ] Consolidate public API for `DaskDataset` and `GPUDatasetIterator` (https://github.com/NVIDIA/NVTabular/issues/60)