### PR TITLE
Refactor shuffle_gdf

### DIFF
--- a/nvtabular/dask/io.py
+++ b/nvtabular/dask/io.py
@@ -36,6 +36,8 @@ from fsspec.core import get_fs_token_paths
 from fsspec.utils import stringify_path
 from pyarrow.compat import guid
 
+from nvtabular.io import _shuffle_gdf
+
 
 class WriterCache:
     def __init__(self):
@@ -82,13 +84,6 @@ def clean_pw_cache():
 def _write_metadata(meta_list):
     # TODO: Write _metadata file here (need to collect metadata)
     return meta_list
-
-
-def _shuffle_gdf(gdf, gdf_size=None):
-    gdf_size = gdf_size or len(gdf)
-    arr = cupy.arange(gdf_size)
-    cupy.random.shuffle(arr)
-    return gdf.iloc[arr]
 
 
 @annotate("write_output_partition", color="green", domain="nvt_python")

--- a/nvtabular/io.py
+++ b/nvtabular/io.py
@@ -527,3 +527,12 @@ class HugeCTR:
 
         for writer in self.writers:
             writer.close()
+
+
+def _shuffle_gdf(gdf, gdf_size=None):
+    """ Shuffles a cudf dataframe, returning a new dataframe with randomly
+    ordered rows """
+    gdf_size = gdf_size or len(gdf)
+    arr = cp.arange(gdf_size)
+    cp.random.shuffle(arr)
+    return gdf.iloc[arr]

--- a/nvtabular/tf_dataloader.py
+++ b/nvtabular/tf_dataloader.py
@@ -9,8 +9,8 @@ import tensorflow as tf
 from packaging import version
 from tensorflow.python.feature_column import feature_column_v2 as fc
 
-from .io import GPUDatasetIterator
-from .workflow import BaseWorkflow, _shuffle_part
+from .io import GPUDatasetIterator, _shuffle_gdf
+from .workflow import BaseWorkflow
 
 free_gpu_mem_mb = rmm.get_info().free / (1024 ** 2)
 tf_mem_size = os.environ.get("TF_MEMORY_ALLOCATION", 0.5)
@@ -273,7 +273,7 @@ class KerasSequenceDataset(tf.keras.utils.Sequence):
             x = workflow.apply_ops(x)
 
         if self.shuffle:
-            x = _shuffle_part(x)
+            x = _shuffle_gdf(x)
         return x
 
     def _process_next_chunk(self):

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -32,12 +32,6 @@ from nvtabular.encoder import DLLabelEncoder
 from nvtabular.io import HugeCTR, Shuffler
 from nvtabular.ops import DFOperator, Export, OperatorRegistry, StatOperator, TransformOperator
 
-try:
-    import cupy as cp
-except ImportError:
-    import numpy as cp
-
-
 LOG = logging.getLogger("nvtabular")
 
 
@@ -960,14 +954,6 @@ def get_new_list_config():
     config["PP"]["continuous"] = []
     config["PP"]["categorical"] = []
     return config
-
-
-def _shuffle_part(gdf):
-    sort_key = "__sort_index__"
-    arr = cp.arange(len(gdf))
-    cp.random.shuffle(arr)
-    gdf[sort_key] = cudf.Series(arr)
-    return gdf.sort_values(sort_key).drop(columns=[sort_key])
 
 
 class DaskWorkflow(BaseWorkflow):


### PR DESCRIPTION
There were two almost identical functions to shuffle a dataframe here,
in workflow.py and dask/io.py. Consolidate to a single version.
