### PR TITLE
[REVIEW] Refactor get_emb_sz

### DIFF
--- a/examples/criteo-example.ipynb
+++ b/examples/criteo-example.ipynb
@@ -44,7 +44,7 @@
     "import torch\n",
     "import rmm\n",
     "import nvtabular as nvt\n",
-    "from nvtabular.ops import Normalize, FillMissing, Categorify, Moments, Median, Encoder, LogOp, ZeroFill\n",
+    "from nvtabular.ops import Normalize, FillMissing, Categorify, Moments, Median, Encoder, LogOp, ZeroFill, get_embedding_size\n",
     "from nvtabular.torch_dataloader import DLDataLoader, TorchTensorBatchDatasetItr, create_tensors_plain\n",
     "\n",
     "# tools for training\n",
@@ -304,7 +304,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embeddings = [x[1] for x in proc.df_ops['Categorify'].get_emb_sz(proc.stats[\"categories\"], proc.columns_ctx['categorical']['base'])]"
+    "embeddings = [x[1] for x in get_embedding_size(proc.stats[\"categories\"], proc.columns_ctx['categorical']['base'])]"
    ]
   },
   {

--- a/examples/criteo_benchmark.py
+++ b/examples/criteo_benchmark.py
@@ -40,7 +40,7 @@ from fastai.tabular import TabularModel
 
 from nvtabular import Workflow
 from nvtabular.io import GPUDatasetIterator, device_mem_size
-from nvtabular.ops import Categorify, LogOp, Normalize, ZeroFill
+from nvtabular.ops import Categorify, LogOp, Normalize, ZeroFill, get_embedding_size
 from nvtabular.torch_dataloader import DLCollator, DLDataLoader, FileItrDataset
 
 
@@ -144,9 +144,7 @@ print(proc.timings)
 
 embeddings = [
     x[1]
-    for x in proc.df_ops["Categorify"].get_emb_sz(
-        proc.stats["categories"], proc.columns_ctx["categorical"]["base"]
-    )
+    for x in get_embedding_size(proc.stats["categories"], proc.columns_ctx["categorical"]["base"])
 ]
 print("Creating Iterators for dataloader")
 start = time()

--- a/examples/gpu_benchmark.ipynb
+++ b/examples/gpu_benchmark.ipynb
@@ -32,7 +32,7 @@
     "import cudf\n",
     "\n",
     "import nvtabular as nvt\n",
-    "from nvtabular.ops import Normalize, FillMissing, Categorify, Moments, Median, Encoder, LogOp, ZeroFill\n",
+    "from nvtabular.ops import Normalize, FillMissing, Categorify, Moments, Median, Encoder, LogOp, ZeroFill, get_embedding_size\n",
     "from nvtabular.torch_dataloader import FileItrDataset, DLCollator, DLDataLoader\n",
     "\n",
     "import warnings\n",
@@ -223,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embeddings = [x[1] for x in proc.df_ops['Categorify'].get_emb_sz(proc.stats[\"categories\"], proc.columns_ctx['categorical']['base'])]"
+    "embeddings = [x[1] for x in get_embedding_size(proc.stats[\"categories\"], proc.columns_ctx['categorical']['base'])]"
    ]
   },
   {

--- a/examples/rossmann-store-sales-example.ipynb
+++ b/examples/rossmann-store-sales-example.ipynb
@@ -243,7 +243,7 @@
     "# based on the number of potential categories, so we'll just use those defaults\n",
     "EMBEDDING_TABLE_SHAPES = {\n",
     "    column: shape for column, shape in\n",
-    "        proc.df_ops['Categorify'].get_emb_sz(\n",
+    "        nvt.ops.get_embedding_size(\n",
     "            proc.stats['categories'], proc.columns_ctx['categorical']['base']\n",
     "        )\n",
     "}\n",

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -1248,7 +1248,7 @@ def get_embedding_order(cat_names):
     cat_names : list of str
         names of the categorical columns
     """
-    return sorted(cat_names, key=lambda entry: entry.split("_")[0])
+    return sorted(cat_names)
 
 
 def get_embedding_size(encoders, cat_names):

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -1154,7 +1154,6 @@ class Categorify(DFOperator):
         Replaces the transformed column with the original input
         if set Yes
     cat_names :
-    embed_sz :
     """
 
     default_in = CAT
@@ -1171,7 +1170,6 @@ class Categorify(DFOperator):
         preprocessing=True,
         replace=True,
         cat_names=None,
-        embed_sz=None,
         out_path=None,
         split_out=None,
         na_sentinel=None,
@@ -1186,7 +1184,6 @@ class Categorify(DFOperator):
         self.gpu_mem_util_limit = gpu_mem_util_limit
         self.gpu_mem_trans_use = gpu_mem_trans_use
         self.cat_names = cat_names if cat_names else []
-        self.embed_sz = embed_sz if embed_sz else {}
         self.out_path = out_path or "./"
         self.split_out = split_out
         self.na_sentinel = na_sentinel or 0
@@ -1242,30 +1239,32 @@ class Categorify(DFOperator):
                 new_gdf[new_col] = new_gdf[new_col].astype(self.dtype, copy=False)
         return new_gdf
 
-    def get_emb_sz(self, encoders, cat_names):
-        # sorted key required to ensure same sort occurs for all values
-        ret_list = [
-            (n, self.def_emb_sz(encoders, n))
-            for n in sorted(cat_names, key=lambda entry: entry.split("_")[0])
-        ]
-        return ret_list
 
-    def emb_sz_rule(self, n_cat: int) -> int:
-        return min(16, round(1.6 * n_cat ** 0.56))
+def get_embedding_order(cat_names):
+    """ Returns a consistent sorder order for categorical variables
 
-    def def_emb_sz(self, classes, n, sz_dict=None):
-        """Pick an embedding size for `n` depending on `classes` if not given in `sz_dict`.
-        """
-        sz_dict = sz_dict if sz_dict else {}
-        n_cat = classes[n]
-        sz = sz_dict.get(n, int(self.emb_sz_rule(n_cat)))  # rule of thumb
-        self.embed_sz[n] = sz
-        return n_cat, sz
+    Parameters
+    -----------
+    cat_names : list of str
+        names of the categorical columns
+    """
+    return sorted(cat_names, key=lambda entry: entry.split("_")[0])
 
-    def get_embeddings(self, encoders, cat_names):
-        embeddings = {}
-        for col in sorted(cat_names):
-            path = encoders[col]
-            num_rows, _, _ = cudf.io.read_parquet_metadata(path)
-            embeddings[col] = (num_rows, self.emb_sz_rule(num_rows))
-        return embeddings
+
+def get_embedding_size(encoders, cat_names):
+    """ Returns a suggested size of embeddings based off cardinality of encoding categorical
+    variables
+    Parameters
+    -----------
+    encoders : dict
+        The encoding statistics of the categorical variables (ie. from workflow.stats["categories"])
+    cat_names : list of str
+        names of the categorical columns
+    """
+    # sorted key required to ensure same sort occurs for all values
+    ret_list = [(n, _emb_sz_rule(encoders[n])) for n in get_embedding_order(cat_names)]
+    return ret_list
+
+
+def _emb_sz_rule(n_cat: int) -> int:
+    return n_cat, int(min(16, round(1.6 * n_cat ** 0.56)))


### PR DESCRIPTION
I recently broke the example notebooks using get_emb_sz, since we no longer have easy access to the Categorify op.

Fix by moving get_emb_sz from a method on the categorify op to a plain function.
Also rename to get_embedding_size, and consolidate the couple of different
spots we were sorted category names to a single function (get_embedding_order).
This fixes  #27
