### PR TITLE
[REVIEW] Use DaskDataset as dataset for unittests

### DIFF
--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -126,6 +126,9 @@ class TransformOperator(Operator):
         if self.replace and self.preprocessing and target_columns:
             if new_gdf.shape[0] < origin_gdf.shape[0]:
                 return new_gdf
+            # handle case when the dropna operator doesn't drop any rows
+            elif new_gdf.shape[1] > len(target_columns):
+                return new_gdf
             else:
                 origin_gdf[target_columns] = new_gdf
                 return origin_gdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,8 @@
 cudf>=0.14
+dask-cudf>=0.14
+dask-cuda>=0.14
 PyYAML>=5.3
+cupy>=7
+dask>=2.12.0
+distributed>=2.12.0
+

--- a/tests/unit/test_dask_nvt.py
+++ b/tests/unit/test_dask_nvt.py
@@ -21,26 +21,10 @@ import cudf
 import dask_cudf
 import pytest
 from dask.dataframe import assert_eq
-from dask.distributed import Client, LocalCluster
 
 import nvtabular.ops as ops
 from nvtabular import DaskDataset, Workflow
 from tests.conftest import allcols_csv, mycols_csv, mycols_pq
-
-# LocalCluster Client Fixture
-client = None
-
-
-@pytest.fixture(scope="module")
-def dask_cluster(request):
-    global client
-    client = Client(LocalCluster(n_workers=2))
-
-    def client_close():
-        global client
-        client.close()
-
-    request.addfinalizer(client_close)
 
 
 # Dummy operator logic to test stats
@@ -60,7 +44,7 @@ def _dummy_op_logic(gdf, target_columns, _id="dummy", **kwargs):
 @pytest.mark.parametrize("engine", ["parquet", "csv", "csv-no-header"])
 @pytest.mark.parametrize("freq_threshold", [0, 150])
 def test_dask_workflow_api_dlrm(
-    dask_cluster, tmpdir, datasets, freq_threshold, part_mem_fraction, engine
+    client, tmpdir, datasets, freq_threshold, part_mem_fraction, engine
 ):
 
     paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
@@ -126,7 +110,7 @@ def test_dask_workflow_api_dlrm(
 
 
 @pytest.mark.parametrize("engine", ["parquet"])
-def test_dask_minmax_dummyop(dask_cluster, tmpdir, datasets, engine):
+def test_dask_minmax_dummyop(client, tmpdir, datasets, engine):
 
     paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
     cat_names = ["name-cat", "name-string"]
@@ -163,7 +147,7 @@ def test_dask_minmax_dummyop(dask_cluster, tmpdir, datasets, engine):
 
 
 @pytest.mark.parametrize("engine", ["parquet"])
-def test_dask_median_dummyop(dask_cluster, tmpdir, datasets, engine):
+def test_dask_median_dummyop(client, tmpdir, datasets, engine):
 
     paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
     cat_names = ["name-cat", "name-string"]
@@ -200,7 +184,7 @@ def test_dask_median_dummyop(dask_cluster, tmpdir, datasets, engine):
 
 
 @pytest.mark.parametrize("engine", ["parquet"])
-def test_dask_normalize(dask_cluster, tmpdir, datasets, engine):
+def test_dask_normalize(client, tmpdir, datasets, engine):
 
     paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
     df1 = cudf.read_parquet(paths[0])[mycols_pq]

--- a/tests/unit/test_torch_dataloader.py
+++ b/tests/unit/test_torch_dataloader.py
@@ -200,7 +200,7 @@ def test_gpu_dl(tmpdir, df, dataset, batch_size, gpu_memory_frac, engine):
     os.mkdir(output_train)
 
     processor.apply(
-        dataset,
+        dataset.to_iter(columns=mycols_pq),
         apply_offline=True,
         record_stats=True,
         shuffle=True,

--- a/tests/unit/test_torch_dataloader.py
+++ b/tests/unit/test_torch_dataloader.py
@@ -36,7 +36,7 @@ torch_dataloader = pytest.importorskip("nvtabular.torch_dataloader")
 @pytest.mark.parametrize("engine", ["csv", "csv-no-header"])
 def test_gpu_file_iterator_ds(df, dataset, batch, engine):
     df_itr = cudf.DataFrame()
-    for data_gd in dataset:
+    for data_gd in dataset.to_iter(columns=mycols_csv):
         df_itr = cudf.concat([df_itr, data_gd], axis=0) if df_itr else data_gd
 
     assert_eq(df_itr.reset_index(drop=True), df.reset_index(drop=True))
@@ -129,7 +129,6 @@ def test_gpu_preproc(tmpdir, df, dataset, dump, gpu_memory_frac, engine, preproc
         assert cats0 == ["None"] + cats_expected0
     cats_expected1 = df["name-string"].unique().values_to_string()
     cats1 = processor.stats["encoders"]["name-string"].get_cats().values_to_string()
-    print(cats1)
     assert cats1 == ["None"] + cats_expected1
 
     #     Write to new "shuffled" and "processed" dataset

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -147,12 +147,9 @@ def test_gpu_dataset_iterator_parquet(datasets, batch):
     assert_eq(df_itr.reset_index(drop=True), df_expect.reset_index(drop=True))
 
 
-@pytest.mark.parametrize("batch", [0, 100, 1000])
 @pytest.mark.parametrize("engine", ["csv", "csv-no-header"])
-def test_gpu_dataset_iterator_csv(datasets, df, dataset, batch, engine):
-    df_itr = cudf.DataFrame()
-    for data_gd in dataset:
-        df_itr = cudf.concat([df_itr, data_gd], axis=0) if df_itr else data_gd
+def test_gpu_dataset_iterator_csv(df, dataset, engine):
+    df_itr = cudf.concat(list(dataset.to_iter(columns=mycols_csv)), axis=0)
     assert_eq(df_itr.reset_index(drop=True), df.reset_index(drop=True))
 
 
@@ -244,7 +241,7 @@ def test_gpu_workflow_config(tmpdir, df, dataset, gpu_memory_frac, engine, dump,
     config["PP"]["categorical"] = [ops.Categorify()]
 
     processor = nvt.Workflow(
-        cat_names=cat_names, cont_names=cont_names, label_name=label_name, config=config,
+        cat_names=cat_names, cont_names=cont_names, label_name=label_name, config=config
     )
 
     processor.update_stats(dataset)


### PR DESCRIPTION
Move unittest fixtures from testing a GPUDatasetIterator to a DaskDataset,
and start using the dask workflow for most of the ops unittests.

This also changes the baseworkflow to accept a GPUDatasetIterator or a
DaskDataset object and moves the dask client fixture to be available for
the entire project
