### PR TITLE
[REVIEW] BugFix FillMissing

### DIFF
--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -813,7 +813,7 @@ class FillMissing(DFOperator):
         cont_names = target_columns
         if not cont_names:
             return gdf
-        z_gdf = gdf[cont_names].fillna(0)
+        z_gdf = gdf[cont_names].fillna(self.fill_val)
         z_gdf.columns = [f"{col}_{self._id}" for col in z_gdf.columns]
         return z_gdf
 

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -215,11 +215,12 @@ def test_fill_missing(tmpdir, df, dataset, engine):
     columns_ctx = {}
     columns_ctx["continuous"] = {}
     columns_ctx["continuous"]["base"] = cont_names
+    for col in cont_names:
+        idx = np.random.choice(df.shape[0] - 1, int(df.shape[0] * 0.2))
+        df[col].iloc[idx] = None
 
-    transformed = cudf.concat(
-        [op.apply_op(df, columns_ctx, "continuous") for df in dataset.to_iter()]
-    )
-    assert_eq(transformed[cont_names], df[cont_names].dropna(42))
+    transformed = cudf.concat([op.apply_op(df, columns_ctx, "continuous")])
+    assert_eq(transformed[cont_names], df[cont_names].fillna(42))
 
 
 @pytest.mark.parametrize("engine", ["parquet"])


### PR DESCRIPTION
The FillMissing operator did not use the parameter fill_val to fill na values.
Instead it used a hardcoded value 0.

The dataset in the unittest did not have any na values. Therefore, it passed.