### PR TITLE
Run criteo-example.ipynb unittest

### DIFF
--- a/examples/criteo-example.ipynb
+++ b/examples/criteo-example.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"3\"\n",
+    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
     "from time import time\n",
     "import re\n",
     "import glob\n",
@@ -45,7 +45,7 @@
     "import torch\n",
     "import rmm\n",
     "import nvtabular as nvt\n",
-    "from nvtabular.ops import Normalize, FillMissing, Categorify, Moments, Median, Encoder, LogOp, ZeroFill, get_embedding_sizes\n",
+    "from nvtabular.ops import Normalize, FillMissing, Categorify, Moments, Median, LogOp, ZeroFill, get_embedding_sizes\n",
     "from nvtabular.torch_dataloader import DLDataLoader, TorchTensorBatchDatasetItr, create_tensors_plain\n",
     "\n",
     "# tools for training\n",
@@ -151,12 +151,7 @@
     "proc.add_cont_preprocess(Normalize())\n",
     "\n",
     "# categorification with frequency thresholding\n",
-    "proc.add_cat_preprocess(Categorify(use_frequency=True, \n",
-    "                                   freq_threshold=15, \n",
-    "                                   on_host=True, \n",
-    "                                   split_out=4, \n",
-    "                                   cat_cache=\"host\",\n",
-    "                                  ))"
+    "proc.add_cat_preprocess(Categorify(freq_threshold=15))\n"
    ]
   },
   {
@@ -263,8 +258,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_data_itrs = TorchTensorBatchDatasetItr(train_paths, engine='parquet', gpu_memory_frac=0.1, sub_batch_size=800000, cats=CATEGORICAL_COLUMNS, conts=CONTINUOUS_COLUMNS, labels=LABEL_COLUMNS)\n",
-    "valid_data_itrs = TorchTensorBatchDatasetItr(valid_paths, engine='parquet', gpu_memory_frac=0.1, sub_batch_size=800000, cats=CATEGORICAL_COLUMNS, conts=CONTINUOUS_COLUMNS, labels=LABEL_COLUMNS)"
+    "train_data_itrs = TorchTensorBatchDatasetItr(train_paths, engine='parquet', sub_batch_size=800000, cats=CATEGORICAL_COLUMNS, conts=CONTINUOUS_COLUMNS, labels=LABEL_COLUMNS)\n",
+    "valid_data_itrs = TorchTensorBatchDatasetItr(valid_paths, engine='parquet', sub_batch_size=800000, cats=CATEGORICAL_COLUMNS, conts=CONTINUOUS_COLUMNS, labels=LABEL_COLUMNS)"
    ]
   },
   {

--- a/examples/criteo_benchmark.py
+++ b/examples/criteo_benchmark.py
@@ -94,12 +94,7 @@ if int(args.freq_thresh) == 0:
     proc.add_preprocess(Categorify(replace=True, out_path=args.out_dir))
 else:
     proc.add_preprocess(
-        Categorify(
-            replace=True,
-            use_frequency=True,
-            freq_threshold=int(args.freq_thresh),
-            out_path=args.out_dir,
-        )
+        Categorify(replace=True, freq_threshold=int(args.freq_thresh), out_path=args.out_dir,)
     )
 print("Creating Dataset Iterator")
 dataset_args = {"sep": "\t"} if args.in_file_type == "csv" else {}

--- a/examples/gpu_benchmark.ipynb
+++ b/examples/gpu_benchmark.ipynb
@@ -32,7 +32,7 @@
     "import cudf\n",
     "\n",
     "import nvtabular as nvt\n",
-    "from nvtabular.ops import Normalize, FillMissing, Categorify, Moments, Median, Encoder, LogOp, ZeroFill, get_embedding_sizes\n",
+    "from nvtabular.ops import Normalize, FillMissing, Categorify, Moments, Median, LogOp, ZeroFill, get_embedding_sizes\n",
     "from nvtabular.torch_dataloader import FileItrDataset, DLCollator, DLDataLoader\n",
     "\n",
     "import warnings\n",
@@ -156,7 +156,7 @@
    "outputs": [],
    "source": [
     "proc.add_cont_preprocess([FillMissing(replace=True), Normalize(replace=True)])\n",
-    "proc.add_cat_preprocess(Categorify(replace=True, use_frequency=True, freq_threshold=1))"
+    "proc.add_cat_preprocess(Categorify(replace=True, freq_threshold=1))"
    ]
   },
   {


### PR DESCRIPTION
Fix the criteo example notebook unittest, and start running it by default.
The unittest was segfaulting due to globals (like rmm) getting unloaded
after the exec call. Fix by running notebooks in a subprocess instead
of the main process.

Also fix some minor errors inside the notebook itself

