### PR TITLE
Build multiple versions of the docs

### DIFF
--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -1,0 +1,27 @@
+{%- if current_version %}
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book"> Other Versions</span>
+    v: {{ current_version.name }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    {%- if versions.tags %}
+    <dl>
+      <dt>Tags</dt>
+      {%- for item in versions.tags %}
+      <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+    {%- if versions.branches %}
+    <dl>
+      <dt>Branches</dt>
+      {%- for item in versions.branches %}
+      <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+  </div>
+</div>
+{%- endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,7 @@ release = "2020"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx_multiversion",
     "sphinx_rtd_theme",
     "recommonmark",
     "sphinx_markdown_tables",
@@ -72,6 +73,13 @@ source_suffix = [".rst", ".md"]
 
 nbsphinx_allow_errors = True
 html_show_sourcelink = False
+
+# Whitelist pattern for tags (set to None to ignore all tags)
+smv_tag_whitelist = r"^v.*$"
+# Only include master branch for now
+smv_branch_whitelist = "^master$"
+
+html_sidebars = {"**": ["versions.html"]}
 
 # certain references in the README couldn't be autoresolved here,
 # hack by forcing to the either the correct documentation page (examples)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ pytest>=5
 recommonmark>=0.6
 Sphinx>=3
 sphinx_markdown_tables
+sphinx-multiversion
 moto
 boto3
 s3fs


### PR DESCRIPTION
Build a version of the docs for each tag as well as the master branch. 
This uses sphinx-multiversion to build the docs for each version, and adds
a link to the bottom of the sidebar to pick between versions - looking something like :
<img width="317" alt="Screen Shot 2020-08-07 at 7 05 56 PM" src="https://user-images.githubusercontent.com/69536/89700204-3cf2ae80-d8e1-11ea-9b47-47f9caef3bff.png">

Needed for #178.
