### PR TITLE
Use main branch as default for NVTabular

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ into three categories:
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/nvidia/NVTabular/blob/master/README.md)
+1. Read the project's [README.md](https://github.com/nvidia/NVTabular/blob/main/README.md)
     to learn how to setup the development environment
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/nvidia/NVTabular/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/nvidia/NVTabular/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,15 +77,15 @@ html_show_sourcelink = False
 
 # Whitelist pattern for tags (set to None to ignore all tags)
 smv_tag_whitelist = r"^v.*$"
-# Only include master branch for now
-smv_branch_whitelist = "^master$"
+# Only include main branch for now
+smv_branch_whitelist = "^main$"
 
 html_sidebars = {"**": ["versions.html"]}
 
 # certain references in the README couldn't be autoresolved here,
 # hack by forcing to the either the correct documentation page (examples)
 # or to a blob on the repo
-_REPO = "https://github.com/NVIDIA/NVTabular/blob/master/"
+_REPO = "https://github.com/NVIDIA/NVTabular/blob/main/"
 _URL_MAP = {
     "./examples": "examples/index",
     "examples/rossmann-store-sales-example.ipynb": "examples/rossmann",


### PR DESCRIPTION
We're updating the default branch for NVTabular to be 'main' instead of 'master'. This PR changes the docs to 
build for the main branch instead, and updates documentation links to go to the main branch instead.