### PR TITLE
Fix cosine similarity mutating input matrix

### DIFF
--- a/docs/source/api/ops/columnsimilarity.rst
+++ b/docs/source/api/ops/columnsimilarity.rst
@@ -1,0 +1,6 @@
+ColumnSimilarity
+================
+
+.. autoclass:: nvtabular.column_similarity.ColumnSimilarity
+   :members:
+   :show-inheritance:

--- a/docs/source/api/ops/index.rst
+++ b/docs/source/api/ops/index.rst
@@ -5,7 +5,8 @@ Operators
    :maxdepth: 2
 
    Categorify <categorify>
-   Clip <Clip>
+   Clip <clip>
+   ColumnSimilarity <columnsimilarity>
    Dropna <dropna>
    FillMissing <fillmissing>
    FillMedian <fillmedian>

--- a/tests/unit/test_column_similarity.py
+++ b/tests/unit/test_column_similarity.py
@@ -48,3 +48,12 @@ def test_column_similarity(on_device, metric):
 
     # distance from document 4 to 5 should be non-zero (have category 1 in common)
     assert output[4] != 0
+
+    # make sure that we can operate multiple times on the same matrix correctly
+    op = ColumnSimilarity(
+        "output", "left", categories, "right", metric="inner", on_device=on_device
+    )
+    df = op.apply_op(
+        cudf.DataFrame({"left": [0, 0, 0, 0, 4], "right": [0, 1, 2, 3, 5]}), None, None
+    )
+    assert float(df.output.values[0]) == pytest.approx(3)


### PR DESCRIPTION
The ColumnSimilarity op was mutating the input matrix on the gpu for the cosine
and tfidf distances. Fix and add a unittest to detect this. Also add the
ColumnSimilarity op to the generated sphinx docs.