### PR TITLE
Cleanup LocalCUDACluster when running unittests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import glob
 import os
 import random
@@ -53,16 +54,15 @@ def client():
     return _CLIENT
 
 
-@pytest.fixture(scope="session")
-def cuda_cluster():
+@contextlib.contextmanager
+def get_cuda_cluster():
     from dask_cuda import LocalCUDACluster
 
-    global _CUDA_CLUSTER
-    if _CUDA_CLUSTER is None:
-        CUDA_VISIBLE_DEVICES = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
-        n_workers = min(2, len(CUDA_VISIBLE_DEVICES.split(",")))
-        _CUDA_CLUSTER = LocalCUDACluster(n_workers=n_workers)
-    return _CUDA_CLUSTER
+    CUDA_VISIBLE_DEVICES = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
+    n_workers = min(2, len(CUDA_VISIBLE_DEVICES.split(",")))
+    cluster = LocalCUDACluster(n_workers=n_workers)
+    yield cluster
+    cluster.close()
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_notebooks.py
+++ b/tests/unit/test_notebooks.py
@@ -8,6 +8,8 @@ from os.path import dirname, realpath
 import cudf
 import pytest
 
+from tests.conftest import get_cuda_cluster
+
 TEST_PATH = dirname(dirname(realpath(__file__)))
 
 
@@ -49,25 +51,25 @@ def test_rossman_example(tmpdir):
     _run_notebook(tmpdir, notebook_path, lambda line: line.replace("EPOCHS = 25", "EPOCHS = 1"))
 
 
-def test_multigpu_dask_example(tmpdir, cuda_cluster):
-    pytest.importorskip("dask_cuda")
-    os.environ["BASE_DIR"] = str(tmpdir)
-    scheduler_port = cuda_cluster.scheduler_address
+def test_multigpu_dask_example(tmpdir):
+    with get_cuda_cluster() as cuda_cluster:
+        os.environ["BASE_DIR"] = str(tmpdir)
+        scheduler_port = cuda_cluster.scheduler_address
 
-    def _nb_modify(line):
-        # Use cuda_cluster "fixture" port rather than allowing notebook
-        # to deploy a LocalCUDACluster within the subprocess
-        line = line.replace("cluster = None", f"cluster = '{scheduler_port}'")
-        # Use a much smaller "toy" dataset
-        line = line.replace("write_count = 25", "write_count = 4")
-        line = line.replace('freq = "1s"', 'freq = "1h"')
-        # Use smaller partitions for smaller dataset
-        line = line.replace("part_mem_fraction=0.1", "part_size=1_000_000")
-        line = line.replace("out_files_per_proc=8", "out_files_per_proc=1")
-        return line
+        def _nb_modify(line):
+            # Use cuda_cluster "fixture" port rather than allowing notebook
+            # to deploy a LocalCUDACluster within the subprocess
+            line = line.replace("cluster = None", f"cluster = '{scheduler_port}'")
+            # Use a much smaller "toy" dataset
+            line = line.replace("write_count = 25", "write_count = 4")
+            line = line.replace('freq = "1s"', 'freq = "1h"')
+            # Use smaller partitions for smaller dataset
+            line = line.replace("part_mem_fraction=0.1", "part_size=1_000_000")
+            line = line.replace("out_files_per_proc=8", "out_files_per_proc=1")
+            return line
 
-    notebook_path = os.path.join(dirname(TEST_PATH), "examples", "multi-gpu_dask.ipynb")
-    _run_notebook(tmpdir, notebook_path, _nb_modify)
+        notebook_path = os.path.join(dirname(TEST_PATH), "examples", "multi-gpu_dask.ipynb")
+        _run_notebook(tmpdir, notebook_path, _nb_modify)
 
 
 def _run_notebook(tmpdir, notebook_path, transform=None):


### PR DESCRIPTION
We initialize a cuda cluster during the multi gpu notebook test, which
can allocate a RMM pool. This causes issues with GPU memory in the
remaining tests. Fix by only keeping the cluster around for the
duration of the test.
