### PR TITLE
fix for running int tests all green

### DIFF
--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -15,6 +15,7 @@ DATA_START = os.environ.get("DATASET_DIR", "/raid/data")
 def test_criteo_notebook(tmpdir):
     input_path = os.path.join(DATA_START, "criteo/crit_int_pq")
     output_path = os.path.join(DATA_START, "criteo/crit_test")
+    os.environ["NUM_PARTS"] = "1"
 
     _run_notebook(
         tmpdir,


### PR DESCRIPTION
Needed change for throttling the criteo notebook data loader in integration tests 