### PR TITLE
Cat fix

### DIFF
--- a/nvtabular/categorify.py
+++ b/nvtabular/categorify.py
@@ -319,6 +319,9 @@ def _groupby_to_disk(
         col = [col] if isinstance(col, str) else col
         col_str = _make_name(*col, sep=name_sep)
         col_groups_str.append(col_str)
+        freq_limit_val = None
+        if freq_limit:
+            freq_limit_val = freq_limit[col_str] if isinstance(freq_limit,dict) else freq_limit
         for s in range(tree_width[col_str]):
             dsk[(level_2_name, c, s)] = (
                 _mid_level_groupby,
@@ -326,7 +329,7 @@ def _groupby_to_disk(
                 col,
                 agg_cols,
                 agg_list,
-                freq_limit,
+                freq_limit_val,
                 on_host,
                 concat_groups,
                 name_sep,

--- a/nvtabular/categorify.py
+++ b/nvtabular/categorify.py
@@ -321,7 +321,7 @@ def _groupby_to_disk(
         col_groups_str.append(col_str)
         freq_limit_val = None
         if freq_limit:
-            freq_limit_val = freq_limit[col_str] if isinstance(freq_limit,dict) else freq_limit
+            freq_limit_val = freq_limit[col_str] if isinstance(freq_limit, dict) else freq_limit
         for s in range(tree_width[col_str]):
             dsk[(level_2_name, c, s)] = (
                 _mid_level_groupby,

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -706,8 +706,7 @@ class GroupbyStatistics(StatOperator):
         self.op_name = "GroupbyStatistics-" + self.stat_name
         self.concat_groups = concat_groups
         self.name_sep = name_sep
-        
-        
+
     @property
     def _id(self):
         return str(self.op_name)
@@ -1014,9 +1013,9 @@ class Categorify(DFOperator):
         Categories with a count/frequency below this threshold will be
         ommited from the encoding and corresponding data will be mapped
         to the "null" category. Can be represented as both an integer or
-        a dictionary with column names as keys and frequency limit as 
+        a dictionary with column names as keys and frequency limit as
         value. If dictionary is used, all columns targeted must be included
-        in the dictionary. 
+        in the dictionary.
     columns : list of str or list(str), default None
         Categorical columns (or multi-column "groups") to target for this op.
         If None, the operation will target all known categorical columns.
@@ -1175,7 +1174,7 @@ class Categorify(DFOperator):
         new_gdf = gdf.copy(deep=False)
         target_columns = self.get_columns(columns_ctx, input_cols, target_cols)
         if isinstance(self.freq_threshold, dict):
-            assert(all(x in self.freq_threshold for x in target_columns))
+            assert all(x in self.freq_threshold for x in target_columns)
         if not target_columns:
             return new_gdf
 
@@ -1216,7 +1215,9 @@ class Categorify(DFOperator):
                 gdf,
                 self.cat_cache,
                 na_sentinel=self.na_sentinel,
-                freq_threshold=self.freq_threshold[name] if isinstance(self.freq_threshold, dict) else self.freq_threshold,
+                freq_threshold=self.freq_threshold[name]
+                if isinstance(self.freq_threshold, dict)
+                else self.freq_threshold,
             )
             if self.dtype:
                 new_gdf[new_col] = new_gdf[new_col].astype(self.dtype, copy=False)

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -1133,7 +1133,7 @@ class Categorify(DFOperator):
 
         # Other self-explanatory intialization
         super().__init__(columns=columns, preprocessing=preprocessing, replace=replace)
-        self.freq_threshold = freq_threshold if freq_threshold else 0
+        self.freq_threshold = freq_threshold or 0
         self.out_path = out_path or "./"
         self.tree_width = tree_width
         self.na_sentinel = na_sentinel or 0

--- a/nvtabular/ops.py
+++ b/nvtabular/ops.py
@@ -1010,10 +1010,13 @@ class Categorify(DFOperator):
 
     Parameters
     -----------
-    freq_threshold : int, default 0
+    freq_threshold : int or dictionary:{column: freq_limit_value}, default 0
         Categories with a count/frequency below this threshold will be
         ommited from the encoding and corresponding data will be mapped
-        to the "null" category.
+        to the "null" category. Can be represented as both an integer or
+        a dictionary with column names as keys and frequency limit as 
+        value. If dictionary is used, all columns targeted must be included
+        in the dictionary. 
     columns : list of str or list(str), default None
         Categorical columns (or multi-column "groups") to target for this op.
         If None, the operation will target all known categorical columns.

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -617,14 +617,34 @@ def test_categorify_multi_combo(tmpdir):
     assert df_out["Author_Engaging User"].to_arrow().to_pylist() == [1, 4, 2, 3]
 
 
-@pytest.mark.parametrize("freq_limit", [None, 0, {"Author": 3, "Engaging User":4}])   
+@pytest.mark.parametrize("freq_limit", [None, 0, {"Author": 3, "Engaging User": 4}])
 def test_categorify_freq_limit(tmpdir, freq_limit):
-
-    kind = "combo"
     df = pd.DataFrame(
         {
-            "Author": ["User_A", "User_E", "User_B", "User_C","User_A", "User_E", "User_B", "User_C","User_B", "User_C"],
-            "Engaging User": ["User_B", "User_B", "User_A", "User_D","User_B", "User_c", "User_A", "User_D", "User_D", "User_D"]
+            "Author": [
+                "User_A",
+                "User_E",
+                "User_B",
+                "User_C",
+                "User_A",
+                "User_E",
+                "User_B",
+                "User_C",
+                "User_B",
+                "User_C",
+            ],
+            "Engaging User": [
+                "User_B",
+                "User_B",
+                "User_A",
+                "User_D",
+                "User_B",
+                "User_c",
+                "User_A",
+                "User_D",
+                "User_D",
+                "User_D",
+            ],
         }
     )
 
@@ -634,7 +654,9 @@ def test_categorify_freq_limit(tmpdir, freq_limit):
 
     processor = nvt.Workflow(cat_names=cat_names, cont_names=cont_names, label_name=label_name)
 
-    processor.add_preprocess(ops.Categorify(columns=cat_names, freq_threshold=freq_limit, out_path=str(tmpdir)))
+    processor.add_preprocess(
+        ops.Categorify(columns=cat_names, freq_threshold=freq_limit, out_path=str(tmpdir))
+    )
     processor.finalize()
     processor.apply(nvt.Dataset(df), output_format=None)
     df_out = processor.get_ddf().compute(scheduler="synchronous")
@@ -646,6 +668,7 @@ def test_categorify_freq_limit(tmpdir, freq_limit):
     else:
         assert len(df["Author"].unique()) == df_out["Author"].max()
         assert len(df["Engaging User"].unique()) == df_out["Engaging User"].max()
+
 
 @pytest.mark.parametrize("groups", [[["Author", "Engaging-User"]], "Author"])
 def test_joingroupby_multi(tmpdir, groups):


### PR DESCRIPTION
Allows for frequency threshold to be set per column dictionary for targeted columns. All targeted columns must be mentioned if using by column dictionary option. 