### PR TITLE
Docs data

### DIFF
--- a/nvtabular/io/dataset.py
+++ b/nvtabular/io/dataset.py
@@ -127,12 +127,12 @@ class Dataset:
         dataset = Dataset(ddf)
 
     Dataset Optimization Tips (DOTs)
-    When creating a NVT Dataset, to get maximum performance from the library,
-    the data must be crafted using parquet format files, with a optimized
-    row group size of 128mb. If your current dataset is represented in a format
-    other than parquet, NVTabular supports reading from CSV files. Take a look at
-    this notebook_, it is used to turn the original unformatted Criteo CSV dataset
-    and create a new parquet dataset optimized for use in an NVT Dataset.
+    The NVTabular dataset should be created from Parquet files in order
+    to get the best possible performance, preferably with a row group size
+    of around 128MB.  While NVTabular also supports reading from CSV files,
+    reading CSV can be over twice as slow as reading from Parquet. Take a
+    look at this notebook_ for an example of transforming the original Criteo
+    CSV dataset into a new Parquet dataset optimized for use with NVTabular.
 
     .. _notebook: https://github.com/NVIDIA/NVTabular/blob/main/examples/optimize_criteo.ipynb
 

--- a/nvtabular/io/dataset.py
+++ b/nvtabular/io/dataset.py
@@ -129,7 +129,7 @@ class Dataset:
     Dataset Optimization Tips (DOTs)
     When creating a NVT Dataset, to get maximum performance from the library,
     the data must be crafted using parquet format files, with a optimized 
-    row group size of 138mb. If your current dataset is represented in a format 
+    row group size of 128mb. If your current dataset is represented in a format 
     other than parquet, NVTabular supports reading from CSV files. Take a look at
     this notebook_, it is used to turn the original unformatted Criteo CSV dataset
     and create a new parquet dataset optimized for use in an NVT Dataset.

--- a/nvtabular/io/dataset.py
+++ b/nvtabular/io/dataset.py
@@ -125,6 +125,17 @@ class Dataset:
         ddf = Dataset("/path/to/data_pq", engine="parquet").to_ddf()
         ddf = ddf.sort_values("user_rank", ignore_index=True)
         dataset = Dataset(ddf)
+    
+    Dataset Optimization Tips (DOTs)
+    When creating a NVT Dataset, to get maximum performance from the library,
+    the data must be crafted using parquet format files, with a optimized 
+    row group size of 138mb. If your current dataset is represented in a format 
+    other than parquet, NVTabular supports reading from CSV files. Take a look at
+    this notebook_, it is used to turn the original unformatted Criteo CSV dataset
+    and create a new parquet dataset optimized for use in an NVT Dataset.
+    
+    .. _notebook: https://github.com/NVIDIA/NVTabular/blob/main/examples/optimize_criteo.ipynb
+    
 
     Parameters
     -----------

--- a/nvtabular/io/dataset.py
+++ b/nvtabular/io/dataset.py
@@ -125,17 +125,17 @@ class Dataset:
         ddf = Dataset("/path/to/data_pq", engine="parquet").to_ddf()
         ddf = ddf.sort_values("user_rank", ignore_index=True)
         dataset = Dataset(ddf)
-    
+
     Dataset Optimization Tips (DOTs)
     When creating a NVT Dataset, to get maximum performance from the library,
-    the data must be crafted using parquet format files, with a optimized 
-    row group size of 128mb. If your current dataset is represented in a format 
+    the data must be crafted using parquet format files, with a optimized
+    row group size of 128mb. If your current dataset is represented in a format
     other than parquet, NVTabular supports reading from CSV files. Take a look at
     this notebook_, it is used to turn the original unformatted Criteo CSV dataset
     and create a new parquet dataset optimized for use in an NVT Dataset.
-    
+
     .. _notebook: https://github.com/NVIDIA/NVTabular/blob/main/examples/optimize_criteo.ipynb
-    
+
 
     Parameters
     -----------


### PR DESCRIPTION
This adds documentation mentioning that the NVT Dataset is optimized for parquet files with a rowgroup size of 128mb. And it links to the optimize_criteo notebook to show user an example of changing a CSV to optimized Parquet format. 