### PR TITLE
Documentation + Notebook fixes

### DIFF
--- a/examples/criteo-example.ipynb
+++ b/examples/criteo-example.ipynb
@@ -30,24 +30,7 @@
     "Here we'll show how to use NVTabular first as a preprocessing library to prepare the [Criteo Display Advertising Challenge](https://www.kaggle.com/c/criteo-display-ad-challenge) dataset, and then as a dataloader to train a FastAI model on the prepared data. The large memory footprint of the Criteo dataset presents a great opportunity to highlight the advantages of the online fashion in which NVTabular loads and transforms data.\n",
     "\n",
     "### Data Prep\n",
-    "Before we get started, make sure you've run the [optimize_criteo](./optimize_criteo.ipynb) notebook, which will convert the tsv data published by Criteo into the parquet format that our accelerated readers prefer. It's fair to mention at this point that that notebook will take ~4 hours to run. While we're hoping to release accelerated csv readers in the near future, we also believe that inefficiencies in existing data representations like csv are in no small part a consequence of inefficiencies in the existing hardware/software stack. Accelerating these pipelines on new hardware like GPUs may require us to make new choices about the representations we use to store that data, and parquet represents a strong alternative."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Quick Aside: Clearing Cache\n",
-    "The following line is not strictly necessary, but is included for those who want to validate NVIDIA's benchmarks. We start by clearing the existing cache to start as \"fresh\" as possible. If you're having trouble running it, try executing the container with the `--privileged` flag."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!sync; echo 3 > /proc/sys/vm/drop_caches"
+    "Before we get started, make sure you've run the [optimize_criteo](./optimize_criteo.ipynb) notebook, which will convert the tsv data published by Criteo into the parquet format that our accelerated readers prefer. It's fair to mention at this point that that notebook will take around 30 minutes to run. While we're hoping to release accelerated csv readers in the near future, we also believe that inefficiencies in existing data representations like csv are in no small part a consequence of inefficiencies in the existing hardware/software stack. Accelerating these pipelines on new hardware like GPUs may require us to make new choices about the representations we use to store that data, and parquet represents a strong alternative."
    ]
   },
   {
@@ -293,7 +276,7 @@
    "source": [
     "## Deep Learning\n",
     "### Data Loading\n",
-    "We'll start by using the parquet files we just created to feed an NVTabular `AsyncTensorBatchDatasetItr`, which will loop through the files in chunks. First, we'll reinitialize our memory pool from earlier to free up some memory so that we can share it with PyTorch."
+    "We'll start by using the parquet files we just created to feed an NVTabular `TorchAsyncItr`, which will loop through the files in chunks. First, we'll reinitialize our memory pool from earlier to free up some memory so that we can share it with PyTorch."
    ]
   },
   {
@@ -493,7 +476,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.6"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/examples/hugectr/criteo-hugectr.ipynb
+++ b/examples/hugectr/criteo-hugectr.ipynb
@@ -30,32 +30,7 @@
     "Here we'll show how to use NVTabular first as a preprocessing library to prepare the [Criteo Display Advertising Challenge](https://www.kaggle.com/c/criteo-display-ad-challenge) dataset, and then train a model using HugeCTR.\n",
     "\n",
     "### Data Prep\n",
-    "Before we get started, make sure you've run the [`optimize_criteo` notebook](./optimize_criteo.ipynb), which will convert the tsv data published by Criteo into the parquet format that our accelerated readers prefer. It's fair to mention at this point that that notebook will take ~4 hours to run. While we're hoping to release accelerated csv readers in the near future, we also believe that inefficiencies in existing data representations like csv are in no small part a consequence of inefficiencies in the existing hardware/software stack. Accelerating these pipelines on new hardware like GPUs may require us to make new choices about the representations we use to store that data, and parquet represents a strong alternative."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Quick Aside: Clearing Cache\n",
-    "The following line is not strictly necessary, but is included for those who want to validate NVIDIA's benchmarks. We start by clearing the existing cache to start as \"fresh\" as possible. If you're having trouble running it, try executing the container with the `--privileged` flag."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/bin/sh: 1: cannot create /proc/sys/vm/drop_caches: Read-only file system\n"
-     ]
-    }
-   ],
-   "source": [
-    "!sync; echo 3 > /proc/sys/vm/drop_caches"
+    "Before we get started, make sure you've run the [optimize_criteo notebook](../optimize_criteo.ipynb), which will convert the tsv data published by Criteo into the parquet format that our accelerated readers prefer. It's fair to mention at this point that that notebook will take ~30 minutes to run. While we're hoping to release accelerated csv readers in the near future, we also believe that inefficiencies in existing data representations like csv are in no small part a consequence of inefficiencies in the existing hardware/software stack. Accelerating these pipelines on new hardware like GPUs may require us to make new choices about the representations we use to store that data, and parquet represents a strong alternative."
    ]
   },
   {
@@ -181,9 +156,7 @@
     "fname = 'day_{}.parquet'\n",
     "num_days = len([i for i in os.listdir(INPUT_DATA_DIR) if re.match(fname.format('[0-9]{1,2}'), i) is not None])\n",
     "train_paths = [os.path.join(INPUT_DATA_DIR, fname.format(day)) for day in range(NUM_TRAIN_DAYS)]\n",
-    "valid_paths = [os.path.join(INPUT_DATA_DIR, fname.format(day)) for day in range(NUM_TRAIN_DAYS, num_days)]\n",
-    "#print(train_paths)\n",
-    "#print(valid_paths)"
+    "valid_paths = [os.path.join(INPUT_DATA_DIR, fname.format(day)) for day in range(NUM_TRAIN_DAYS, num_days)]"
    ]
   },
   {
@@ -245,9 +218,7 @@
     "    dict_dtypes[col] = np.int64\n",
     "    \n",
     "for col in LABEL_COLUMNS:\n",
-    "    dict_dtypes[col] = np.float32\n",
-    "\n",
-    "#print(dict_dtypes)"
+    "    dict_dtypes[col] = np.float32"
    ]
   },
   {
@@ -470,7 +441,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.6"
   },
   "mimetype": "text/x-python",
   "name": "python",
@@ -481,4 +452,3 @@
  "nbformat": 4,
  "nbformat_minor": 4
 }
-

--- a/examples/rossmann-store-sales-example.ipynb
+++ b/examples/rossmann-store-sales-example.ipynb
@@ -1079,7 +1079,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.6"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/nvtabular/ops/clip.py
+++ b/nvtabular/ops/clip.py
@@ -24,7 +24,7 @@ class Clip(TransformOperator):
     """
     This operation clips continuous values so that they are within a min/max bound.
     For instance by setting the min value to 0, you can replace all negative values with 0.
-    This is helpful in cases where you want to log normalize values:
+    This is helpful in cases where you want to log normalize values::
 
         # clip all continuous columns to be positive only, and then take the log of the clipped
         # columns


### PR DESCRIPTION
* Fix ‘Clip’ example documentation not rendering appropriately
* HugeCTR processing notebook doesn’t link to the preprocessing notebook in the parent directory
* Update to say the optimize criteo script only takes 30 minutes now
* Remove drop cache code from notebooks (should only run as part of benchmarks instead)
* Change AsyncTensorBatchDatasetItr to TorchAsyncItr
