### PR TITLE
Add io-threads flag to dask-crieteo benchmark

### DIFF
--- a/examples/MultiGPUBench.md
+++ b/examples/MultiGPUBench.md
@@ -59,6 +59,12 @@ By default, the Dask-CUDA workers will begin spilling data from device memory to
 
 e.g. `--device-limit-frac 0.66`
 
+##### IO Threads (Writing)
+By default, multi-threading will not be used to write output data. Some systems may see better performance when 2+ threads are used to overlap sequencial writes by the same worker. The user can specify a specific number of threads using the `--num-io-threads` flag.
+
+e.g. `--num-io-threads 2`
+
+Note that multi-threading may reduce the optimal partition size (see the `--part-mem-frac` flag below).
 
 ### Data-Decomposition Options
 

--- a/examples/dask-nvtabular-criteo-benchmark.py
+++ b/examples/dask-nvtabular-criteo-benchmark.py
@@ -177,10 +177,15 @@ def main(args):
                 shuffle=shuffle,
                 out_files_per_proc=out_files_per_proc,
                 output_path=output_path,
+                num_io_threads=args.num_io_threads,
             )
     else:
         processor.apply(
-            dataset, shuffle=shuffle, out_files_per_proc=out_files_per_proc, output_path=output_path
+            dataset,
+            num_io_threads=args.num_io_threads,
+            shuffle=shuffle,
+            out_files_per_proc=out_files_per_proc,
+            output_path=output_path,
         )
     runtime = time.time() - runtime
 
@@ -191,6 +196,7 @@ def main(args):
     print(f"device(s)          | {args.devices}")
     print(f"rmm-pool-frac      | {(args.device_pool_frac)}")
     print(f"out-files-per-proc | {args.out_files_per_proc}")
+    print(f"num_io_threads     | {args.num_io_threads}")
     print(f"shuffle            | {args.shuffle}")
     print(f"cats-on-device     | {args.cats_on_device}")
     print("======================================")
@@ -239,6 +245,13 @@ def parse_args():
         type=float,
         help="RMM pool size for each worker  as a fraction of GPU capacity (Default 0.9). "
         "If 0 is specified, the RMM pool will be disabled",
+    )
+    parser.add_argument(
+        "--num-io-threads",
+        default=0,
+        type=int,
+        help="Number of threads to use when writing output data (Default 0). "
+        "If 0 is specified, multi-threading will not be used for IO.",
     )
 
     #


### PR DESCRIPTION
Adds `--num-io-threads` flag to `NVTabular/examples/dask-nvtabular-criteo-benchmark.py`.

On a DGX-1, I get slightly improved performance with (compared to no `--num-io-threads` flag):

```
$ python dask-nvtabular-criteo-benchmark.py --data-path /path-to/crit_pq_int --out-path /path-to/scratch  --cats-on-device --part-mem-frac 0.14 -p ucx --num-io-threads 2

Dask-NVTabular DLRM/Criteo benchmark
--------------------------------------
partition size     | 4772562206
protocol           | ucx
device(s)          | 0,1,2,3,4,5,6,7
rmm-pool-frac      | 0.9
out-files-per-proc | 8
num_io_threads     | 2
shuffle            | PER_PARTITION
cats-on-device     | True
======================================
Runtime[s]         | 152.97985243797302
======================================
```

<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
