### PR TITLE
Make our conda package 'noarch'

### DIFF
--- a/conda/recipes/meta.yaml
+++ b/conda/recipes/meta.yaml
@@ -18,7 +18,8 @@ source:
 
 build:
   number: {{ git_revision_count }}
-  string: cuda{{ cuda_version }}_py{{ py_version }}_{{ git_revision_count }}
+  string: {{ git_revision_count }}
+  noarch: python
 
 requirements:
   build:
@@ -33,7 +34,6 @@ requirements:
     - dask>=2.12.0
     - distributed>=2.12.0
     - PyYAML>=5.3
-    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
 about:
   home: https://github.com/NVIDIA/NVTabular


### PR DESCRIPTION
Our conda package could only be installed with cuda10.2.  Since we
are a pure python package this is a bit of an arbitrary restriction.
Fix by marking our package as pure python with the ```noarch: python```
setting in the conda recipe.

