### PR TITLE
Use official nvtx package

### DIFF
--- a/conda/environments/nvtabular_dev_cuda10.0.yml
+++ b/conda/environments/nvtabular_dev_cuda10.0.yml
@@ -18,6 +18,7 @@ dependencies:
   - pyarrow=0.15.0
   - fastavro>=0.22.9
   - notebook>=0.5.0
+  - nvtx>=0.2.1
   - cython>=0.29,<0.30
   - fsspec>=0.6.0
   - pytest

--- a/conda/environments/nvtabular_dev_cuda10.1.yml
+++ b/conda/environments/nvtabular_dev_cuda10.1.yml
@@ -18,6 +18,7 @@ dependencies:
   - pyarrow=0.15.0
   - fastavro>=0.22.9
   - notebook>=0.5.0
+  - nvtx>=0.2.1
   - cython>=0.29,<0.30
   - fsspec>=0.6.0
   - pytest

--- a/conda/environments/nvtabular_dev_cuda10.2.yml
+++ b/conda/environments/nvtabular_dev_cuda10.2.yml
@@ -18,6 +18,7 @@ dependencies:
   - pyarrow=0.15.0
   - fastavro>=0.22.9
   - notebook>=0.5.0
+  - nvtx>=0.2.1
   - cython>=0.29,<0.30
   - fsspec>=0.6.0
   - pytest

--- a/conda/recipes/meta.yaml
+++ b/conda/recipes/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - dask>=2.12.0
     - distributed>=2.12.0
     - PyYAML>=5.3
+    - nvtx>=0.2.1
 
 about:
   home: https://github.com/NVIDIA/NVTabular

--- a/nvtabular/io/dask.py
+++ b/nvtabular/io/dask.py
@@ -16,10 +16,10 @@
 import collections
 
 import dask
-from cudf._lib.nvtx import annotate
 from dask.base import tokenize
 from dask.delayed import Delayed
 from dask.highlevelgraph import HighLevelGraph
+from nvtx import annotate
 
 from nvtabular.worker import clean_worker_cache, get_worker_cache
 

--- a/nvtabular/io/parquet.py
+++ b/nvtabular/io/parquet.py
@@ -22,12 +22,12 @@ from io import BytesIO
 from uuid import uuid4
 
 import cudf
-from cudf._lib.nvtx import annotate
 from cudf.io.parquet import ParquetWriter as pwriter
 from dask.base import tokenize
 from dask.dataframe.core import new_dd_object
 from dask.dataframe.io.parquet.utils import _analyze_paths
 from dask.utils import natural_sort_key
+from nvtx import annotate
 from pyarrow import parquet as pq
 
 from .dataset_engine import DatasetEngine

--- a/nvtabular/io/writer.py
+++ b/nvtabular/io/writer.py
@@ -20,8 +20,8 @@ import threading
 
 import cupy as cp
 import numpy as np
-from cudf._lib.nvtx import annotate
 from fsspec.core import get_fs_token_paths
+from nvtx import annotate
 
 
 class Writer:

--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -21,8 +21,6 @@ import cudf
 import cupy as cp
 import numpy as np
 import pyarrow as pa
-import pyarrow.parquet as pq
-from cudf._lib.nvtx import annotate
 from cudf.core.column import as_column, build_column
 from cudf.io.parquet import ParquetWriter
 from cudf.utils.dtypes import is_list_dtype
@@ -31,6 +29,8 @@ from dask.core import flatten
 from dask.dataframe.core import _concat
 from dask.highlevelgraph import HighLevelGraph
 from fsspec.core import get_fs_token_paths
+from nvtx import annotate
+from pyarrow import parquet as pq
 
 from nvtabular.worker import fetch_table_data, get_worker_cache
 

--- a/nvtabular/ops/clip.py
+++ b/nvtabular/ops/clip.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import cudf
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .operator import CONT
 from .transform_operator import TransformOperator

--- a/nvtabular/ops/column_similarity.py
+++ b/nvtabular/ops/column_similarity.py
@@ -19,7 +19,7 @@ import cupy.sparse
 import numba
 import numpy
 import scipy.sparse
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .operator import CAT, CONT
 from .transform_operator import TransformOperator

--- a/nvtabular/ops/difference_lag.py
+++ b/nvtabular/ops/difference_lag.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import cudf
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .operator import CONT
 from .transform_operator import TransformOperator

--- a/nvtabular/ops/dropna.py
+++ b/nvtabular/ops/dropna.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import cudf
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .operator import ALL
 from .transform_operator import TransformOperator

--- a/nvtabular/ops/fill.py
+++ b/nvtabular/ops/fill.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import cudf
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .median import Median
 from .operator import CONT

--- a/nvtabular/ops/filter.py
+++ b/nvtabular/ops/filter.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import cudf
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .operator import ALL
 from .transform_operator import TransformOperator

--- a/nvtabular/ops/hash_bucket.py
+++ b/nvtabular/ops/hash_bucket.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import cudf
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .operator import CAT
 from .transform_operator import TransformOperator

--- a/nvtabular/ops/lambdaop.py
+++ b/nvtabular/ops/lambdaop.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import cudf
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .operator import ALL
 from .transform_operator import TransformOperator

--- a/nvtabular/ops/logop.py
+++ b/nvtabular/ops/logop.py
@@ -15,7 +15,7 @@
 #
 import cudf
 import numpy as np
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .operator import CONT
 from .transform_operator import TransformOperator

--- a/nvtabular/ops/median.py
+++ b/nvtabular/ops/median.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .stat_operator import StatOperator
 

--- a/nvtabular/ops/minmax.py
+++ b/nvtabular/ops/minmax.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .stat_operator import StatOperator
 

--- a/nvtabular/ops/moments.py
+++ b/nvtabular/ops/moments.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .stat_operator import StatOperator
 

--- a/nvtabular/ops/normalize.py
+++ b/nvtabular/ops/normalize.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import cudf
-from cudf._lib.nvtx import annotate
+from nvtx import annotate
 
 from .minmax import MinMax
 from .moments import Moments


### PR DESCRIPTION
the nvtx annotations we're importing from cudf will be unsupported as of
cudf 0.17. Fix by using the official nvtx package instead

Closes #332 