### PR TITLE
separate to correct behavior

### DIFF
--- a/nvtabular/loader/torch.py
+++ b/nvtabular/loader/torch.py
@@ -80,7 +80,9 @@ class TorchAsyncItr(torch.utils.data.IterableDataset, DataLoader):
         if gdf.empty:
             return
         dl_pack = gdf.to_dlpack()
-        tens = from_dlpack(dl_pack).type(dtype)
+        # keep next two lines separated, hurts perf, casts incorrectly
+        tens = from_dlpack(dl_pack)
+        tens = tens.type(dtype)
         return tens
 
     # TODO: do we need casting or can we replace this with


### PR DESCRIPTION
This removes a perf hit we were taking... the casting to dtype is corrupted, however structure is maintained. The problems are only seen when you are training... Results in a AUC hit of about 0.02 (very big). With this fix, AUC is within 0.0001. This fixes the AUC discrepancies with JoC DLRM model tests.
