### PR TITLE
fastai v2 2nd part

### DIFF
--- a/benchmarks/torch/criteo/criteo-example-basedl.ipynb
+++ b/benchmarks/torch/criteo/criteo-example-basedl.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,16 +52,12 @@
     "# from nvtabular.loader.torch import TorchAsyncItr, DLDataLoader\n",
     "# from nvtabular.utils import device_mem_size\n",
     "\n",
-    "# tools for training\n",
-    "from fastai.basic_train import Learner\n",
-    "from fastai.basic_data import DataBunch\n",
-    "from fastai.tabular import TabularModel\n",
-    "from fastai.metrics import accuracy"
+    "# tools for training"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/benchmarks/torch/criteo/criteo-example-iterdl.ipynb
+++ b/benchmarks/torch/criteo/criteo-example-iterdl.ipynb
@@ -51,11 +51,7 @@
     "from nvtabular.loader.torch import TorchAsyncItr, DLDataLoader\n",
     "from nvtabular.utils import device_mem_size\n",
     "\n",
-    "# tools for training\n",
-    "from fastai.basic_train import Learner\n",
-    "from fastai.basic_data import DataBunch\n",
-    "from fastai.tabular import TabularModel\n",
-    "from fastai.metrics import accuracy"
+    "# tools for training"
    ]
   },
   {

--- a/benchmarks/torch/criteo/criteo-example-nvtdl.ipynb
+++ b/benchmarks/torch/criteo/criteo-example-nvtdl.ipynb
@@ -59,11 +59,7 @@
     "from nvtabular.loader.torch import TorchAsyncItr, DLDataLoader\n",
     "from nvtabular.utils import device_mem_size\n",
     "\n",
-    "# tools for training\n",
-    "from fastai.basic_train import Learner\n",
-    "from fastai.basic_data import DataBunch\n",
-    "from fastai.tabular import TabularModel\n",
-    "from fastai.metrics import accuracy"
+    "# tools for training"
    ]
   },
   {
@@ -599,7 +595,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.8"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/benchmarks/torch/criteo/criteo-example-petastorm.ipynb
+++ b/benchmarks/torch/criteo/criteo-example-petastorm.ipynb
@@ -42,11 +42,7 @@
     "from nvtabular.loader.torch import TorchAsyncItr, DLDataLoader\n",
     "from nvtabular.utils import device_mem_size\n",
     "\n",
-    "# tools for training\n",
-    "from fastai.basic_train import Learner\n",
-    "from fastai.basic_data import DataBunch\n",
-    "from fastai.tabular import TabularModel\n",
-    "from fastai.metrics import accuracy"
+    "# tools for training"
    ]
   },
   {

--- a/examples/criteo-example.ipynb
+++ b/examples/criteo-example.ipynb
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,9 +54,9 @@
     "from nvtabular.utils import device_mem_size\n",
     "\n",
     "# tools for training\n",
-    "from fastai.basic_train import Learner\n",
-    "from fastai.basic_data import DataBunch\n",
-    "from fastai.tabular import TabularModel\n",
+    "from fastai.basics import Learner\n",
+    "from fastai.tabular.model import TabularModel\n",
+    "from fastai.tabular.data import TabularDataLoaders\n",
     "from fastai.metrics import accuracy"
    ]
   },
@@ -70,14 +70,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/nvtabular/nvtabular/utils.py:47: UserWarning: get_memory_info is not supported. Using total device memory from NVML.\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/nvtabular/utils.py:47: UserWarning: get_memory_info is not supported. Using total device memory from NVML.\n",
       "  warnings.warn(\"get_memory_info is not supported. Using total device memory from NVML.\")\n"
      ]
     }
@@ -96,13 +96,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "# define some information about where to get our data\n",
-    "INPUT_DATA_DIR = os.environ.get('INPUT_DATA_DIR', '/raid/criteo/tests/crit_int_pq')\n",
-    "OUTPUT_DATA_DIR = os.environ.get('OUTPUT_DATA_DIR', '/raid/criteo/tests/test_dask') # where we'll save our procesed data to\n",
+    "INPUT_DATA_DIR = os.environ.get('INPUT_DATA_DIR', '/raid/criteo/')\n",
+    "OUTPUT_DATA_DIR = os.environ.get('OUTPUT_DATA_DIR', '/raid/test_dask') # where we'll save our procesed data to\n",
     "BATCH_SIZE = int(os.environ.get('BATCH_SIZE', 800000))\n",
     "PARTS_PER_CHUNK = int(os.environ.get('PARTS_PER_CHUNK', 2))\n",
     "NUM_TRAIN_DAYS = 23 # number of days worth of data to use for training, the rest will be used for validation\n",
@@ -116,18 +116,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "_metadata\tday_12.parquet\tday_17.parquet\tday_21.parquet\tday_5.parquet\n",
-      "day_0.parquet\tday_13.parquet\tday_18.parquet\tday_22.parquet\tday_6.parquet\n",
-      "day_1.parquet\tday_14.parquet\tday_19.parquet\tday_23.parquet\tday_7.parquet\n",
-      "day_10.parquet\tday_15.parquet\tday_2.parquet\tday_3.parquet\tday_8.parquet\n",
-      "day_11.parquet\tday_16.parquet\tday_20.parquet\tday_4.parquet\tday_9.parquet\n"
+      "_metadata\tday_12.parquet\tday_17.parquet\tday_21.parquet\tday_5.parquet\r\n",
+      "day_0.parquet\tday_13.parquet\tday_18.parquet\tday_22.parquet\tday_6.parquet\r\n",
+      "day_1.parquet\tday_14.parquet\tday_19.parquet\tday_23.parquet\tday_7.parquet\r\n",
+      "day_10.parquet\tday_15.parquet\tday_2.parquet\tday_3.parquet\tday_8.parquet\r\n",
+      "day_11.parquet\tday_16.parquet\tday_20.parquet\tday_4.parquet\tday_9.parquet\r\n"
      ]
     }
    ],
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,15 +227,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 11min 43s, sys: 6min 55s, total: 18min 39s\n",
-      "Wall time: 21min 12s\n"
+      "CPU times: user 11min 40s, sys: 13min 36s, total: 25min 17s\n",
+      "Wall time: 26min 26s\n"
      ]
     }
    ],
@@ -246,15 +246,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 18.2 s, sys: 15.5 s, total: 33.6 s\n",
-      "Wall time: 51.9 s\n"
+      "CPU times: user 18.1 s, sys: 40.2 s, total: 58.3 s\n",
+      "Wall time: 1min 1s\n"
      ]
     }
    ],
@@ -281,14 +281,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/nvtabular/nvtabular/utils.py:47: UserWarning: get_memory_info is not supported. Using total device memory from NVML.\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/nvtabular/utils.py:47: UserWarning: get_memory_info is not supported. Using total device memory from NVML.\n",
       "  warnings.warn(\"get_memory_info is not supported. Using total device memory from NVML.\")\n"
      ]
     }
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,24 +343,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
     "def gen_col(batch):\n",
-    "    batch = batch[0]\n",
-    "    return (batch[0], batch[1]), batch[2].long()"
+    "    return (batch[0], batch[1], batch[2].long())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_dataloader = DLDataLoader(train_data_itrs, collate_fn=gen_col, pin_memory=False, num_workers=0)\n",
-    "valid_dataloader = DLDataLoader(valid_data_itrs, collate_fn=gen_col, pin_memory=False, num_workers=0)\n",
-    "databunch = DataBunch(train_dataloader, valid_dataloader, collate_fn=gen_col, device=\"cuda\")"
+    "train_dataloader = DLDataLoader(train_data_itrs, collate_fn=gen_col, batch_size=None, pin_memory=False, num_workers=0)\n",
+    "valid_dataloader = DLDataLoader(valid_data_itrs, collate_fn=gen_col, batch_size=None, pin_memory=False, num_workers=0)\n",
+    "databunch = TabularDataLoaders(train_dataloader, valid_dataloader)"
    ]
   },
   {
@@ -380,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,13 +388,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = TabularModel(emb_szs=embeddings, n_cont=len(CONTINUOUS_COLUMNS), out_sz=2, layers=[512, 256]).cuda()\n",
+    "learn =  Learner(databunch, model, loss_func = torch.nn.CrossEntropyLoss(), metrics=[accuracy])"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = TabularModel(emb_szs=embeddings, n_cont=len(CONTINUOUS_COLUMNS), out_sz=2, layers=[512, 256])\n",
-    "learn =  Learner(databunch, model, metrics=[accuracy])\n",
-    "learn.loss_func = torch.nn.CrossEntropyLoss()"
+    "from fastai.callback.schedule import fit_one_cycle"
    ]
   },
   {
@@ -404,41 +411,11 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>accuracy</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.122545</td>\n",
-       "      <td>0.124736</td>\n",
-       "      <td>0.966609</td>\n",
-       "      <td>1:46:27</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6387.76979637146\n"
+      "[0, 0.12467262893915176, 0.12468979507684708, 0.9666252732276917, '2:26:41']\n",
+      "8801.142189741135\n"
      ]
     }
    ],
@@ -446,25 +423,19 @@
     "learning_rate = 1.32e-2\n",
     "epochs = 1\n",
     "start = time()\n",
-    "learn.fit_one_cycle(epochs, learning_rate)\n",
+    "#learn.fit(epochs, learning_rate)\n",
+    "fit_one_cycle(learn, n_epoch=epochs, lr_max=learning_rate)\n",
     "t_final = time() - start\n",
     "print(t_final)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "file_extension": ".py",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "firstEnv",
    "language": "python",
-   "name": "python3"
+   "name": "firstenv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -476,7 +447,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.8"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/examples/criteo-example.ipynb
+++ b/examples/criteo-example.ipynb
@@ -57,7 +57,8 @@
     "from fastai.basics import Learner\n",
     "from fastai.tabular.model import TabularModel\n",
     "from fastai.tabular.data import TabularDataLoaders\n",
-    "from fastai.metrics import accuracy"
+    "from fastai.metrics import accuracy\n",
+    "from fastai.callback.progress import ProgressCallback"
    ]
   },
   {
@@ -393,7 +394,7 @@
    "outputs": [],
    "source": [
     "model = TabularModel(emb_szs=embeddings, n_cont=len(CONTINUOUS_COLUMNS), out_sz=2, layers=[512, 256]).cuda()\n",
-    "learn =  Learner(databunch, model, loss_func = torch.nn.CrossEntropyLoss(), metrics=[accuracy])"
+    "learn =  Learner(databunch, model, loss_func = torch.nn.CrossEntropyLoss(), metrics=[accuracy], cbs=ProgressCallback())"
    ]
   },
   {
@@ -435,7 +436,7 @@
   "kernelspec": {
    "display_name": "rapids",
    "language": "python",
-   "name": "rapids"
+   "name": "myenv"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/gpu_benchmark.ipynb
+++ b/examples/gpu_benchmark.ipynb
@@ -34,12 +34,11 @@
     "import numpy as np\n",
     "from time import time \n",
     "\n",
-    "from fastai import *\n",
-    "from fastai.basic_data import *\n",
-    "from fastai.basic_data import *\n",
-    "from fastai.tabular import *\n",
-    "from fastai.basic_data import DataBunch\n",
-    "from fastai.tabular import TabularModel\n",
+    "import fastai\n",
+    "from fastai.basics import Learner\n",
+    "from fastai.tabular.model import TabularModel\n",
+    "from fastai.tabular.data import TabularDataLoaders\n",
+    "from fastai.metrics import accuracy\n",
     "\n",
     "import cudf\n",
     "\n",
@@ -61,7 +60,7 @@
     {
      "data": {
       "text/plain": [
-       "('1.6.0', '0+untagged.1.gfa8e9fb')"
+       "('1.6.0', '0+untagged.1.gfa8e9fb', '2.0.16')"
       ]
      },
      "execution_count": 3,
@@ -70,7 +69,7 @@
     }
    ],
    "source": [
-    "torch.__version__, cudf.__version__"
+    "torch.__version__, cudf.__version__, fastai.__version__"
    ]
   },
   {
@@ -97,13 +96,13 @@
    "outputs": [],
    "source": [
     "# data_path = '/rapids/notebooks/jperez/Documents/ds-itr/examples/'\n",
-    "INPUT_DATA_DIR = os.environ.get('INPUT_DATA_DIR', '/datasets/outbrain/jp_out/outbrains/input/')\n",
-    "OUTPUT_DATA_DIR = os.environ.get('OUTPUT_DATA_DIR', '/datasets/outbrain/jp_out/outbrains/output/')\n",
+    "INPUT_DATA_DIR = os.environ.get('INPUT_DATA_DIR', '/raid/outbrain1/preprocessed')\n",
+    "OUTPUT_DATA_DIR = os.environ.get('OUTPUT_DATA_DIR', '/raid/outbrain1/output')\n",
     "BATCH_SIZE = int(os.environ.get('BATCH_SIZE', 400000))\n",
     "data_path = INPUT_DATA_DIR\n",
     "#df_test = 'test/'\n",
     "df_valid = os.path.join(data_path, 'validation_feature_vectors_integral.csv/')\n",
-    "df_train = os.path.join(data_path, 'train_feature_vectors_integral_eval.csv/')\n",
+    "df_train = os.path.join(data_path, 'train_feature_vectors_integral_eval_imputed.csv/')\n",
     "\n",
     "train_set = [os.path.join(df_train, x) for x in os.listdir(df_train) if x.startswith(\"part\")] \n",
     "valid_set = [os.path.join(df_valid, x) for x in os.listdir(df_valid) if x.startswith(\"part\")]"
@@ -117,7 +116,7 @@
     {
      "data": {
       "text/plain": [
-       "(200, 100)"
+       "(196, 4)"
       ]
      },
      "execution_count": 6,
@@ -173,8 +172,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 10 µs, sys: 9 µs, total: 19 µs\n",
-      "Wall time: 26.9 µs\n"
+      "CPU times: user 8 µs, sys: 21 µs, total: 29 µs\n",
+      "Wall time: 36.7 µs\n"
      ]
     }
    ],
@@ -202,15 +201,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 26.4 ms, sys: 144 ms, total: 171 ms\n",
-      "Wall time: 250 ms\n"
+      "CPU times: user 2.57 ms, sys: 0 ns, total: 2.57 ms\n",
+      "Wall time: 2.59 ms\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "trains_itrs = nvt.Dataset(train_set,names=cols, engine='csv')\n",
-    "valids_itrs = nvt.Dataset(valid_set,names=cols, engine='csv')"
+    "trains_itrs = nvt.Dataset(train_set,names=cols, engine='csv',part_size='100MB')\n",
+    "valids_itrs = nvt.Dataset(valid_set,names=cols, engine='csv',part_size='200MB')"
    ]
   },
   {
@@ -225,18 +224,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 3min 20s, sys: 2min 23s, total: 5min 43s\n",
-      "Wall time: 6min 51s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "proc.apply(trains_itrs, apply_offline=True, record_stats=True, output_path=output_path_train, shuffle=None)"
@@ -244,18 +234,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 26.9 s, sys: 35.5 s, total: 1min 2s\n",
-      "Wall time: 1min 24s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "proc.apply(valids_itrs, apply_offline=True, record_stats=False, output_path=output_path_valid, shuffle=None)"
@@ -263,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,37 +270,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(4064, 16),\n",
-       " (418296, 16),\n",
-       " (11570727, 16),\n",
-       " (863, 16),\n",
-       " (6829, 16),\n",
-       " (636483, 16),\n",
-       " (890, 16),\n",
-       " (7994, 16),\n",
-       " (143857, 16),\n",
-       " (217, 16),\n",
-       " (975, 16),\n",
-       " (1273, 16),\n",
-       " (7, 5),\n",
-       " (7, 5),\n",
-       " (3, 3),\n",
-       " (2, 2),\n",
-       " (4, 3),\n",
-       " (3, 3)]"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "embeddings"
    ]
@@ -333,18 +286,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 428 ms, sys: 338 ms, total: 766 ms\n",
-      "Wall time: 1.31 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "t_batch_sets = nvt.Dataset(new_train_set, engine='parquet') \n",
@@ -353,17 +297,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "train_dataset = TorchAsyncItr(t_batch_sets, \n",
-    "                              batch_size=100000, \n",
+    "                              batch_size=50000, \n",
     "                              cats=cat_names, \n",
     "                              conts=cont_names, \n",
     "                              labels=[\"label\"])\n",
     "valid_dataset = TorchAsyncItr(v_batch_sets, \n",
-    "                              batch_size=100000, \n",
+    "                              batch_size=50000, \n",
     "                              cats=cat_names, \n",
     "                              conts=cont_names, \n",
     "                              labels=[\"label\"])"
@@ -378,29 +322,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def gen_col(batch):\n",
-    "    batch = batch[0]\n",
-    "    return (batch[0], batch[1]), batch[2].long()"
+    "    return (batch[0], batch[1], batch[2].long())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 101 µs, sys: 79 µs, total: 180 µs\n",
-      "Wall time: 189 µs\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "t_data = DLDataLoader(train_dataset, collate_fn=gen_col, pin_memory=False, num_workers=0)\n",
@@ -416,33 +350,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "databunch = DataBunch(t_data, v_data, collate_fn=gen_col, device=\"cuda\")"
+    "databunch = TabularDataLoaders(t_data, v_data, collate_fn=gen_col)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 8.28 s, sys: 389 ms, total: 8.67 s\n",
-      "Wall time: 4.27 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "model = TabularModel(emb_szs = embeddings, n_cont=len(cont_names), out_sz=2, layers=[512,256])\n",
     "\n",
-    "learn =  Learner(databunch, model, metrics=[accuracy])\n",
-    "learn.loss_func = torch.nn.CrossEntropyLoss()\n"
+    "learn =  Learner(databunch, model, loss_func = torch.nn.CrossEntropyLoss(), metrics=[accuracy])"
    ]
   },
   {
@@ -636,9 +560,9 @@
  "metadata": {
   "file_extension": ".py",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "rapids",
    "language": "python",
-   "name": "python3"
+   "name": "rapids"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/gpu_benchmark.ipynb
+++ b/examples/gpu_benchmark.ipynb
@@ -303,7 +303,7 @@
    "outputs": [],
    "source": [
     "train_dataset = TorchAsyncItr(t_batch_sets, \n",
-    "                              batch_size=50000, \n",
+    "                              batch_size=100000, \n",
     "                              cats=cat_names, \n",
     "                              conts=cont_names, \n",
     "                              labels=[\"label\"])\n",

--- a/examples/gpu_benchmark.ipynb
+++ b/examples/gpu_benchmark.ipynb
@@ -39,6 +39,7 @@
     "from fastai.tabular.model import TabularModel\n",
     "from fastai.tabular.data import TabularDataLoaders\n",
     "from fastai.metrics import accuracy\n",
+    "from fastai.callback.progress import ProgressCallback\n",
     "\n",
     "import cudf\n",
     "\n",
@@ -366,7 +367,7 @@
     "%%time\n",
     "model = TabularModel(emb_szs = embeddings, n_cont=len(cont_names), out_sz=2, layers=[512,256])\n",
     "\n",
-    "learn =  Learner(databunch, model, loss_func = torch.nn.CrossEntropyLoss(), metrics=[accuracy])"
+    "learn =  Learner(databunch, model, loss_func = torch.nn.CrossEntropyLoss(), metrics=[accuracy], cbs=ProgressCallback())"
    ]
   },
   {
@@ -562,7 +563,7 @@
   "kernelspec": {
    "display_name": "rapids",
    "language": "python",
-   "name": "rapids"
+   "name": "myenv"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/rossmann-store-sales-example.ipynb
+++ b/examples/rossmann-store-sales-example.ipynb
@@ -48,26 +48,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/conda/envs/rapids/lib/python3.7/site-packages/numba/cuda/envvars.py:17: NumbaWarning: \n",
-      "Environment variables with the 'NUMBAPRO' prefix are deprecated and consequently ignored, found use of NUMBAPRO_NVVM=/usr/local/cuda/nvvm/lib64/libnvvm.so.\n",
-      "\n",
-      "For more information about alternatives visit: ('http://numba.pydata.org/numba-doc/latest/cuda/overview.html', '#cudatoolkit-lookup')\n",
-      "  warnings.warn(errors.NumbaWarning(msg))\n",
-      "/conda/envs/rapids/lib/python3.7/site-packages/numba/cuda/envvars.py:17: NumbaWarning: \n",
-      "Environment variables with the 'NUMBAPRO' prefix are deprecated and consequently ignored, found use of NUMBAPRO_LIBDEVICE=/usr/local/cuda/nvvm/libdevice/.\n",
-      "\n",
-      "For more information about alternatives visit: ('http://numba.pydata.org/numba-doc/latest/cuda/overview.html', '#cudatoolkit-lookup')\n",
-      "  warnings.warn(errors.NumbaWarning(msg))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import numpy as np\n",
@@ -85,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -142,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -341,11 +324,11 @@
        " 'CompetitionOpenSinceYear': (24, 9),\n",
        " 'Day': (32, 11),\n",
        " 'DayOfWeek': (8, 5),\n",
-       " 'Events': (23, 9),\n",
+       " 'Events': (22, 9),\n",
        " 'Month': (13, 7),\n",
        " 'Promo2SinceYear': (9, 5),\n",
        " 'Promo2Weeks': (27, 10),\n",
-       " 'PromoInterval': (5, 4),\n",
+       " 'PromoInterval': (4, 3),\n",
        " 'Promo_bw': (7, 5),\n",
        " 'Promo_fw': (7, 5),\n",
        " 'SchoolHoliday_bw': (9, 5),\n",
@@ -360,7 +343,7 @@
        " 'Year': (4, 3)}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -770,7 +753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -779,7 +762,7 @@
        "'2.0.16'"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -792,7 +775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -802,6 +785,7 @@
     "from fastai.tabular.model import TabularModel\n",
     "from fastai.basics import Learner\n",
     "from fastai.basics import MSELossFlat\n",
+    "from fastai.callback.progress import ProgressCallback\n",
     "\n",
     "def make_batched_dataloader(paths, columns, batch_size):\n",
     "    dataset = nvt.Dataset(paths)\n",
@@ -823,7 +807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -843,7 +827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -868,40 +852,231 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch | train_loss | valid_loss | exp_rmspe | time\n",
-      "[0, 0.5914298295974731, 1.7097594738006592, 0.7024290561676025, '00:01']\n",
-      "[1, 0.32159191370010376, 0.30050820112228394, 0.4121261537075043, '00:01']\n",
-      "[2, 0.21097460389137268, 0.14749018847942352, 0.46846067905426025, '00:01']\n",
-      "[3, 0.15147575736045837, 0.13266043365001678, 0.4561026096343994, '00:01']\n",
-      "[4, 0.11483695358037949, 0.09379333257675171, 0.3508610129356384, '00:01']\n",
-      "[5, 0.09046000242233276, 0.049926646053791046, 0.22511616349220276, '00:01']\n",
-      "[6, 0.07330150157213211, 0.029001789167523384, 0.17216403782367706, '00:01']\n",
-      "[7, 0.060783714056015015, 0.026516852900385857, 0.17128325998783112, '00:01']\n",
-      "[8, 0.051380593329668045, 0.02673865295946598, 0.17548124492168427, '00:01']\n",
-      "[9, 0.04417378827929497, 0.02590866945683956, 0.17327438294887543, '00:01']\n",
-      "[10, 0.03854868561029434, 0.025085801258683205, 0.1712493598461151, '00:01']\n",
-      "[11, 0.03410271927714348, 0.024627991020679474, 0.17007213830947876, '00:01']\n",
-      "[12, 0.030855972319841385, 0.02388511225581169, 0.16547268629074097, '00:01']\n",
-      "[13, 0.02796274796128273, 0.0224724393337965, 0.15812398493289948, '00:01']\n",
-      "[14, 0.025736074894666672, 0.023614615201950073, 0.16047589480876923, '00:01']\n",
-      "[15, 0.024142595008015633, 0.021364785730838776, 0.1535574346780777, '00:01']\n",
-      "[16, 0.022718021646142006, 0.02288525179028511, 0.1551249772310257, '00:01']\n",
-      "[17, 0.021498365327715874, 0.021922118961811066, 0.1596207320690155, '00:01']\n",
-      "[18, 0.020326996222138405, 0.020661966875195503, 0.15215429663658142, '00:01']\n",
-      "[19, 0.01918923668563366, 0.020063256844878197, 0.14760953187942505, '00:01']\n",
-      "[20, 0.018225332722067833, 0.020861957222223282, 0.1549302488565445, '00:01']\n",
-      "[21, 0.01747661456465721, 0.020155953243374825, 0.14769744873046875, '00:01']\n",
-      "[22, 0.01689755916595459, 0.01989835314452648, 0.1451054960489273, '00:01']\n",
-      "[23, 0.016448255628347397, 0.022762198001146317, 0.15580642223358154, '00:01']\n",
-      "[24, 0.016067449003458023, 0.01908671110868454, 0.14568457007408142, '00:01']\n"
-     ]
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>exp_rmspe</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>exp_rmspe</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.215761</td>\n",
+       "      <td>0.164155</td>\n",
+       "      <td>0.331342</td>\n",
+       "      <td>00:02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.127483</td>\n",
+       "      <td>0.071673</td>\n",
+       "      <td>0.246229</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>0.088330</td>\n",
+       "      <td>0.032615</td>\n",
+       "      <td>0.181555</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>3</td>\n",
+       "      <td>0.066506</td>\n",
+       "      <td>0.025614</td>\n",
+       "      <td>0.167483</td>\n",
+       "      <td>00:02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>4</td>\n",
+       "      <td>0.052737</td>\n",
+       "      <td>0.023265</td>\n",
+       "      <td>0.160165</td>\n",
+       "      <td>00:02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>5</td>\n",
+       "      <td>0.043378</td>\n",
+       "      <td>0.022198</td>\n",
+       "      <td>0.157680</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>6</td>\n",
+       "      <td>0.036673</td>\n",
+       "      <td>0.021151</td>\n",
+       "      <td>0.154265</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>7</td>\n",
+       "      <td>0.031675</td>\n",
+       "      <td>0.020010</td>\n",
+       "      <td>0.150160</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>8</td>\n",
+       "      <td>0.027837</td>\n",
+       "      <td>0.019383</td>\n",
+       "      <td>0.147319</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>9</td>\n",
+       "      <td>0.024828</td>\n",
+       "      <td>0.018521</td>\n",
+       "      <td>0.144329</td>\n",
+       "      <td>00:02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>10</td>\n",
+       "      <td>0.022422</td>\n",
+       "      <td>0.017908</td>\n",
+       "      <td>0.142639</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>11</td>\n",
+       "      <td>0.020478</td>\n",
+       "      <td>0.017056</td>\n",
+       "      <td>0.137023</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>12</td>\n",
+       "      <td>0.018876</td>\n",
+       "      <td>0.016584</td>\n",
+       "      <td>0.135137</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>13</td>\n",
+       "      <td>0.017551</td>\n",
+       "      <td>0.016209</td>\n",
+       "      <td>0.133011</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>14</td>\n",
+       "      <td>0.016442</td>\n",
+       "      <td>0.015912</td>\n",
+       "      <td>0.132330</td>\n",
+       "      <td>00:02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>15</td>\n",
+       "      <td>0.015490</td>\n",
+       "      <td>0.015565</td>\n",
+       "      <td>0.130401</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>16</td>\n",
+       "      <td>0.014674</td>\n",
+       "      <td>0.015242</td>\n",
+       "      <td>0.128135</td>\n",
+       "      <td>00:02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>17</td>\n",
+       "      <td>0.013970</td>\n",
+       "      <td>0.015026</td>\n",
+       "      <td>0.128424</td>\n",
+       "      <td>00:02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>18</td>\n",
+       "      <td>0.013368</td>\n",
+       "      <td>0.014852</td>\n",
+       "      <td>0.126099</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>19</td>\n",
+       "      <td>0.012857</td>\n",
+       "      <td>0.014560</td>\n",
+       "      <td>0.124652</td>\n",
+       "      <td>00:02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>20</td>\n",
+       "      <td>0.012413</td>\n",
+       "      <td>0.014460</td>\n",
+       "      <td>0.125070</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>21</td>\n",
+       "      <td>0.012033</td>\n",
+       "      <td>0.014333</td>\n",
+       "      <td>0.122164</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>22</td>\n",
+       "      <td>0.011745</td>\n",
+       "      <td>0.013983</td>\n",
+       "      <td>0.121915</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>23</td>\n",
+       "      <td>0.011450</td>\n",
+       "      <td>0.014362</td>\n",
+       "      <td>0.127220</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>24</td>\n",
+       "      <td>0.011145</td>\n",
+       "      <td>0.014084</td>\n",
+       "      <td>0.122282</td>\n",
+       "      <td>00:02</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -915,10 +1090,16 @@
     "    return torch.sqrt((pct_var**2).mean())\n",
     "\n",
     "loss_func = MSELossFlat()\n",
-    "learner = Learner(databunch, pt_model, loss_func=loss_func, metrics=[exp_rmspe])\n",
-    "print('Epoch | train_loss | valid_loss | exp_rmspe | time')\n",
+    "learner = Learner(databunch, pt_model, loss_func=loss_func, metrics=[exp_rmspe], cbs=ProgressCallback())\n",
     "learner.fit(EPOCHS, LEARNING_RATE)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -926,7 +1107,7 @@
   "kernelspec": {
    "display_name": "rapids",
    "language": "python",
-   "name": "rapids"
+   "name": "myenv"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Updated notebookes

```
examples/criteo-example.ipynb
examples/gpu_benchmark.ipynb
benchmarks/torch/criteo/criteo-example-petastorm.ipynb
benchmarks/torch/criteo/criteo-example-iterdl.ipynb
benchmarks/torch/criteo/criteo-example-nvtdl.ipynb
benchmarks/torch/criteo/criteo-example-basedl.ipynb
```

Ran examples/criteo-example.ipynb end-2-end on NGC (slow but worked)

Changed examples/gpu_benchmark.ipynb but I am not able to run the notebook

Removed fastai imports after discussion it with @jperez999 as it was not used in the notebooks:
benchmarks/torch/criteo/criteo-example-petastorm.ipynb
benchmarks/torch/criteo/criteo-example-iterdl.ipynb
benchmarks/torch/criteo/criteo-example-nvtdl.ipynb
benchmarks/torch/criteo/criteo-example-basedl.ipynb

Added ProgressBar to criteo-example, gpu_benchmark and rossmann-example