### PR TITLE
Cleanup dask client in unittests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,16 +57,14 @@ mynames = [
     "Zelda",
 ]
 
-_CLIENT = None
 _CUDA_CLUSTER = None
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def client():
-    global _CLIENT
-    if _CLIENT is None:
-        _CLIENT = Client(LocalCluster(n_workers=2))
-    return _CLIENT
+    client = Client(LocalCluster(n_workers=2))
+    yield client
+    client.close()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
The dask client was getting created in test_dask_nvt, and was kept alive for the entire session.
This can cause issues later on in other unittests. Fix by explicitly closing the client after
we're done with it, and only keeping alive at the module scope
