### PR TITLE
Fix for workflows that generate new columns

### DIFF
--- a/nvtabular/io/parquet.py
+++ b/nvtabular/io/parquet.py
@@ -98,7 +98,8 @@ class ParquetDatasetEngine(DatasetEngine):
         return dask_cudf.read_parquet(
             self.paths,
             columns=columns,
-            index=False,
+            # can't omit reading the index in if we aren't being passed columns
+            index=None if columns is None else False,
             gather_statistics=False,
             split_row_groups=self.row_groups_per_part,
             storage_options=self.storage_options,

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -585,8 +585,10 @@ class Workflow(BaseWorkflow):
         if self.ddf is None:
             raise ValueError("No dask_cudf frame available.")
         elif isinstance(self.ddf, Dataset):
-            columns = self.columns_ctx["all"]["base"]
-            return self.ddf.to_ddf(columns=columns, shuffle=self._shuffle_parts)
+            # Right now we can't distinguish between input columns and generated columns
+            # in the dataset, we don't limit the columm set right now in the to_ddf call
+            # (https://github.com/NVIDIA/NVTabular/issues/409 )
+            return self.ddf.to_ddf(shuffle=self._shuffle_parts)
         return self.ddf
 
     @staticmethod


### PR DESCRIPTION
Generating a new column in the workflow and then using that in a future op
wasn't working properly (#409). This adds a quick fix to revert to the previous
behaviour of not limiting columns in the read_parquet call.