### PR TITLE
Fixes binary duplicated names

### DIFF
--- a/nvtabular/io/hugectr.py
+++ b/nvtabular/io/hugectr.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+from uuid import uuid4
 
 import numpy as np
 
@@ -24,9 +25,13 @@ class HugeCTRWriter(ThreadedWriter):
     def __init__(self, out_dir, **kwargs):
         super().__init__(out_dir, **kwargs)
         if self.use_guid:
-            self.data_paths = [os.path.join(out_dir, f"{i}i.{guid()}.data") for i in range(self.num_out_files)]
+            self.data_paths = [
+                os.path.join(out_dir, f"{i}i.{uuid4().hex}.data") for i in range(self.num_out_files)
+            ]
         else:
-            self.data_paths = [os.path.join(out_dir, f"{i}.data") for i in range(self.num_out_files)]
+            self.data_paths = [
+                os.path.join(out_dir, f"{i}.data") for i in range(self.num_out_files)
+            ]
         self.data_writers = [open(f, "wb") for f in self.data_paths]
         # Reserve 64 bytes for header
         header = np.array([0, 0, 0, 0, 0, 0, 0, 0], dtype=np.longlong)

--- a/nvtabular/io/hugectr.py
+++ b/nvtabular/io/hugectr.py
@@ -23,7 +23,10 @@ from .writer import ThreadedWriter
 class HugeCTRWriter(ThreadedWriter):
     def __init__(self, out_dir, **kwargs):
         super().__init__(out_dir, **kwargs)
-        self.data_paths = [os.path.join(out_dir, f"{i}.data") for i in range(self.num_out_files)]
+        if self.use_guid:
+            self.data_paths = [os.path.join(out_dir, f"{i}i.{guid()}.data") for i in range(self.num_out_files)]
+        else:
+            self.data_paths = [os.path.join(out_dir, f"{i}.data") for i in range(self.num_out_files)]
         self.data_writers = [open(f, "wb") for f in self.data_paths]
         # Reserve 64 bytes for header
         header = np.array([0, 0, 0, 0, 0, 0, 0, 0], dtype=np.longlong)


### PR DESCRIPTION
When using HugeCTR Format, we were having duplicated filenames when using dask, updated to work in the same way that parquet is workig.

I think for version 0.4, we should be improving the HugeCTR writer, to look similar to Parquet, and support not only Binary but also Norm format.