### PR TITLE
Documentation Fixes

### DIFF
--- a/docs/source/api/ops/hashedcross.rst
+++ b/docs/source/api/ops/hashedcross.rst
@@ -1,0 +1,6 @@
+HashedCross
+===========
+
+.. autoclass:: nvtabular.ops.HashedCross
+   :members:
+   :show-inheritance:

--- a/docs/source/examples/outbrain.ipynb
+++ b/docs/source/examples/outbrain.ipynb
@@ -1,1 +1,1 @@
-../../../examples/wnd_outbrain/E2E-NVT.ipynb
+../../../examples/wnd_outbrain/Outbrain.ipynb

--- a/nvtabular/framework_utils/tensorflow/layers/embedding.py
+++ b/nvtabular/framework_utils/tensorflow/layers/embedding.py
@@ -140,16 +140,16 @@ class DenseFeatures(tf.keras.layers.Layer):
     by `tf.keras.layers.DenseFeatures` while reducing overhead for the
     case of one-hot categorical and scalar numeric features.
 
-    Uses TensorFlow `feature_column`s to represent inputs to the layer, but
+    Uses TensorFlow `feature_column` to represent inputs to the layer, but
     does not perform any preprocessing associated with those columns. As such,
-    it should only be passed `numeric_column`s and their subclasses,
+    it should only be passed `numeric_column` objects and their subclasses,
     `embedding_column` and `indicator_column`. Preprocessing functionality should
     be moved to NVTabular.
 
     For multi-hot categorical or vector continuous data, represent the data for
     a feature with a dictionary entry `"<feature_name>__values"` corresponding
     to the flattened array of all values in the batch. For multi-hot categorical
-    data, there should be a corresponding `"<feature_name>__nnzs" entry that
+    data, there should be a corresponding `"<feature_name>__nnzs"` entry that
     describes how many categories are present in each sample (and so has length
     `batch_size`).
 

--- a/nvtabular/framework_utils/tensorflow/layers/interaction.py
+++ b/nvtabular/framework_utils/tensorflow/layers/interaction.py
@@ -29,6 +29,7 @@ class DotProductInteraction(tf.keras.layers.Layer):
     tensors of shape `(batch_size, num_features, embedding_dim)` to
     tensors of shape `(batch_size, (num_features - 1)*num_features // 2)`
     if `self_interaction` is `False`, otherwise `(batch_size, num_features**2)`.
+
     Parameters
     ------------------------
     interaction_type: {}

--- a/nvtabular/loader/backend.py
+++ b/nvtabular/loader/backend.py
@@ -35,6 +35,7 @@ class ChunkQueue:
      and concatenates them into a cudf dataframe "chunk". This chunk
     is subsequently transformed into its tensor representation using
     the iterator's transform.
+
     Parameters
     -----------
     qsize: int

--- a/nvtabular/loader/tensorflow.py
+++ b/nvtabular/loader/tensorflow.py
@@ -90,7 +90,7 @@ class KerasSequenceLoader(tf.keras.utils.Sequence, DataLoader):
     """
     Infinite generator used to asynchronously iterate through CSV or Parquet
     dataframes on GPU by leveraging an NVTabular `Dataset`. Applies preprocessing
-    via NVTabular `Workflow`s and outputs tabular dictionaries of TensorFlow
+    via NVTabular `Workflow` objects and outputs tabular dictionaries of TensorFlow
     Tensors via `dlpack <https://github.com/dmlc/dlpack>`_. Useful for training tabular models
     built in Keras and trained via
     `tf.keras.Model.fit <https://www.tensorflow.org/api_docs/python/tf/keras/Model>`_.

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -322,6 +322,7 @@ class BaseWorkflow:
         """
         Adds categorical feature engineering operator(s), while mapping
         to the correct columns given operator dependencies.
+
         Parameters
         -----------
         operators : object
@@ -338,6 +339,7 @@ class BaseWorkflow:
         """
         Adds continuous feature engineering operator(s)
         to the workflow.
+
         Parameters
         -----------
         operators : object
@@ -353,6 +355,7 @@ class BaseWorkflow:
         """
         Adds categorical pre-processing operator(s)
         to the workflow.
+
         Parameters
         -----------
         operators : object
@@ -368,6 +371,7 @@ class BaseWorkflow:
         """
         Adds continuous pre-processing operator(s)
         to the workflow.
+
         Parameters
         -----------
         operators : object
@@ -550,6 +554,7 @@ class BaseWorkflow:
         """
         Returns all the column names after preprocessing and feature
         engineering.
+
         Parameters
         -----------
         col_type : str


### PR DESCRIPTION
 * fix symlink to outbrain notebook so it shows in the docs again
 * add missing rst file to hashedcross operator
 * fix docstring errors with 'Parameters' not being rendered correctly (need whitespace before)
 * fix TF docstring issues with backquotes being followed by characters

