### PR TITLE
Documentation fixes for the rossmann example

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -88,7 +88,7 @@ html_sidebars = {"**": ["versions.html"]}
 _REPO = "https://github.com/NVIDIA/NVTabular/blob/main/"
 _URL_MAP = {
     "./examples": "examples/index",
-    "examples/rossmann-store-sales-example.ipynb": "examples/rossmann",
+    "examples/rossmann/": "examples/rossmann/index",
     "examples/criteo-example.ipynb": "examples/criteo",
     "./CONTRIBUTING": _REPO + "/CONTRIBUTING.md",
     "./Operators": _REPO + "/Operators.md",

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -5,7 +5,7 @@ Examples
    :maxdepth: 2
 
    Criteo Example <criteo>
-   Rossmann Example <rossmann>
+   Rossmann Example <rossmann/index>
    Multi-GPU Example <multigpu>
    HugeCTR Example <hugectr>
    Outbrain Example <outbrain>

--- a/docs/source/examples/rossmann.ipynb
+++ b/docs/source/examples/rossmann.ipynb
@@ -1,1 +1,0 @@
-../../../examples/rossmann-store-sales-example.ipynb

--- a/docs/source/examples/rossmann/fastai.ipynb
+++ b/docs/source/examples/rossmann/fastai.ipynb
@@ -1,0 +1,1 @@
+../../../../examples/rossmann/rossmann-store-sales-fastai.ipynb

--- a/docs/source/examples/rossmann/feature-engineering.ipynb
+++ b/docs/source/examples/rossmann/feature-engineering.ipynb
@@ -1,0 +1,1 @@
+../../../../examples/rossmann/rossmann-store-sales-feature-engineering.ipynb

--- a/docs/source/examples/rossmann/index.rst
+++ b/docs/source/examples/rossmann/index.rst
@@ -1,0 +1,11 @@
+Rossmann Example
+================
+
+.. toctree::
+   :maxdepth: 2
+
+   Download and Preprocess <preproc>
+   Feature Engineering <feature-engineering>
+   TensorFlow <tensorflow>
+   PyTorch <pytorch>
+   FastAI <fastai>

--- a/docs/source/examples/rossmann/preproc.ipynb
+++ b/docs/source/examples/rossmann/preproc.ipynb
@@ -1,0 +1,1 @@
+../../../../examples/rossmann/rossmann-store-sales-preproc.ipynb

--- a/docs/source/examples/rossmann/pytorch.ipynb
+++ b/docs/source/examples/rossmann/pytorch.ipynb
@@ -1,0 +1,1 @@
+../../../../examples/rossmann/rossmann-store-sales-pytorch.ipynb

--- a/docs/source/examples/rossmann/tensorflow.ipynb
+++ b/docs/source/examples/rossmann/tensorflow.ipynb
@@ -1,0 +1,1 @@
+../../../../examples/rossmann/rossmann-store-sales-tensorflow.ipynb


### PR DESCRIPTION
We recently split the rossmann example into multiple notebooks, which
broke the rendered sphinx docs. Fix by adding symlinks to the correct
notebooks, updating the url overrides and adding an index.rst page
to link it all together.

