### PR TITLE
Uses cudf 0.17

### DIFF
--- a/nvtabular/io/parquet.py
+++ b/nvtabular/io/parquet.py
@@ -135,9 +135,11 @@ class ParquetWriter(ThreadedWriter):
                 if self.bytes_io:
                     bio = BytesIO()
                     self.data_bios.append(bio)
-                    self.data_writers.append(pwriter(bio, compression=None))
+                    # Passing index=False when creating ParquetWriter
+                    # to avoid bug: https://github.com/rapidsai/cudf/issues/7011
+                    self.data_writers.append(pwriter(bio, compression=None, index=False))
                 else:
-                    self.data_writers.append(pwriter(path, compression=None))
+                    self.data_writers.append(pwriter(path, compression=None, index=False))
 
             return self.data_writers[idx]
 

--- a/tests/unit/test_dask_nvt.py
+++ b/tests/unit/test_dask_nvt.py
@@ -121,7 +121,11 @@ def test_dask_workflow_api_dlrm(
             assert_eq(result[col], df_disk[col])
 
     else:
-        df_disk = dask_cudf.read_parquet(output_path, index=False).compute()
+        # Removed index as a parameter due to an error when updating to cudf 0.17
+        # There is a bug in Dask that Rick is fixing
+        # Rick's PR: https://github.com/dask/dask/pull/6969
+        # df_disk = dask_cudf.read_parquet(output_path, index=False).compute()
+        df_disk = dask_cudf.read_parquet(output_path).compute()
         assert len(df0) == len(df_disk)
 
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -94,7 +94,7 @@ def test_dask_dataset(datasets, engine, num_files):
         dataset = nvtabular.io.Dataset(paths, header=False, names=allcols_csv)
         result = dataset.to_ddf(columns=mycols_csv)
 
-    assert_eq(ddf0, result)
+    assert_eq(ddf0, result, check_index=False)
 
 
 @pytest.mark.parametrize("output_format", ["hugectr", "parquet"])

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -1029,16 +1029,16 @@ def test_difference_lag():
     op = ops.DifferenceLag("userid", shift=[1, -1], columns=["timestamp"])
     new_gdf = op.apply_op(df, columns_ctx, "all", target_cols=["timestamp"])
 
-    assert new_gdf["timestamp_DifferenceLag_1"][0] is None
+    assert new_gdf["timestamp_DifferenceLag_1"][0] is cudf.NA 
     assert new_gdf["timestamp_DifferenceLag_1"][1] == 5
     assert new_gdf["timestamp_DifferenceLag_1"][2] == 95
-    assert new_gdf["timestamp_DifferenceLag_1"][3] is None
+    assert new_gdf["timestamp_DifferenceLag_1"][3] is cudf.NA
 
     assert new_gdf["timestamp_DifferenceLag_-1"][0] == -5
     assert new_gdf["timestamp_DifferenceLag_-1"][1] == -95
-    assert new_gdf["timestamp_DifferenceLag_-1"][2] is None
+    assert new_gdf["timestamp_DifferenceLag_-1"][2] is cudf.NA
     assert new_gdf["timestamp_DifferenceLag_-1"][3] == -1
-    assert new_gdf["timestamp_DifferenceLag_-1"][5] is None
+    assert new_gdf["timestamp_DifferenceLag_-1"][5] is cudf.NA
 
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])


### PR DESCRIPTION
Errors found when using cudf 0.17:

1. `KeyError: None` in `tests/unit/test_dask_nvt.py::test_dask_workflow_api_dlrm`
    - This is due to a Dask bug. @rjzamora  has already submitted a [PR](https://github.com/dask/dask/pull/6969); and until we update to the next Dask version as a work around we can just avoid the flag `index=False` in NVTabular

2. `AssertionError: DataFrame.index` are different in `tests/unit/test_io.py::test_dask_dataset`
    - This error is happening when reading multiple parquet files. Trying to fix it adding the flag `check_index=False` since we don't care about matching indices in NVTabular. That solved the Parquet error, but creates errors for csv. @rjzamora does not get the csv errors and it works for him.

3. `assert <NA> is None` in `test_ops.py::test_difference_lag`
    - Having a frame with `dtype: bool`, we were doing the following operation `mask[mask == False] = None`. The resulting dataframe contains `<NA>` values instead of `None`. This is expected, cudf has stopped using None and instead is using `<NA>` to be coherent with pandas (`cudf.NA`).

4. `ValueError: Length mismatch: Expected axis has` in test_workflow.py, test_torch_dataloader.py, test_ops.py, and test_io.py
    - We are getting many errors like `ValueError: Length mismatch: Expected axis has 10 elements, new values have 2 elements`. @rjzamora was guessing to be a cudf bug for reading BytesIO Objects, he has raisen [an issue in cudf](https://github.com/rapidsai/cudf/issues/7011). Keith Kraus guess that it may be related to the boolean masking change if "doing something like gdf[gdf['col'] == x] where any value of gdf['col'] which is <NA> will return False for the purpose of boolean masking". 

**TODO: Fix errors**:
- [X] Fix `KeyError: None`
- [ ] Fix `AssertionError: DataFrame.index`
- [X] Fix `assert <NA> is None`
- [ ] Fix `ValueError: Length mismatch: Expected axis has`
