### PR TITLE
Unittest ops + bugfix in Bucketize

### DIFF
--- a/nvtabular/ops/bucketize.py
+++ b/nvtabular/ops/bucketize.py
@@ -45,6 +45,5 @@ class Bucketize(Operator):
             val = 0
             for boundary in b:
                 val += (gdf[col] >= boundary).astype("int")
-            new_col = f"{col}_{self._id}"
-            new_gdf[new_col] = val
+            new_gdf[col] = val
         return new_gdf

--- a/nvtabular/ops/hashed_cross.py
+++ b/nvtabular/ops/hashed_cross.py
@@ -25,16 +25,15 @@ class HashedCross(Operator):
         self.num_buckets = num_buckets
 
     @annotate("HashedCross_op", color="darkgreen", domain="nvt_python")
-    def op_logic(self, columns, gdf: cudf.DataFrame):
+    def transform(self, columns, gdf: cudf.DataFrame):
         new_gdf = cudf.DataFrame()
-        for cross in columns:
-            val = 0
-            for column in cross:
-                val ^= gdf[column].hash_values()  # or however we want to do this aggregation
-            # TODO: support different size buckets per cross
-            val = val % self.bucket_size
-            new_gdf["_X_".join(cross)] = val
+        val = 0
+        for column in columns:
+            val ^= gdf[column].hash_values()  # or however we want to do this aggregation
+        # TODO: support different size buckets per cross
+        val = val % self.num_buckets
+        new_gdf["_X_".join(columns)] = val
         return new_gdf
 
     def output_column_names(self, columns):
-        return ["_X_".join(cross) for cross in columns]
+        return ["_X_".join(columns)]

--- a/nvtabular/ops/join_external.py
+++ b/nvtabular/ops/join_external.py
@@ -88,7 +88,7 @@ class JoinExternal(Operator):
         cache="host",
         **kwargs,
     ):
-        super().__init__(replace=False)
+        super(JoinExternal).__init__()
         self.on = on
         self.df_ext = df_ext
         self.on_ext = on_ext or self.on
@@ -155,9 +155,9 @@ class JoinExternal(Operator):
         return new_gdf
 
     def output_column_names(self, columns):
-        if self.ext_columns:
-            return columns + self.ext_columns
-        return columns + self._ext.columns
+        if self.columns_ext:
+            return list(set(columns + self.columns_ext))
+        return list(set(columns + list(self._ext.columns)))
 
 
 def _detect_format(data):


### PR DESCRIPTION
Updates unittest for ops

The unittest fails, when I call them at once, but if I call the failed unittest individually, they run successful

```
pytest tests/unit/test_ops.py
================================================= short test summary info =================================================
FAILED tests/unit/test_ops.py::test_hash_bucket_lists - concurrent.futures._base.CancelledError
FAILED tests/unit/test_ops.py::test_categorify_lists[0] - concurrent.futures._base.CancelledError
FAILED tests/unit/test_ops.py::test_categorify_lists[1] - concurrent.futures._base.CancelledError
FAILED tests/unit/test_ops.py::test_categorify_lists[2] - concurrent.futures._base.CancelledError
======================================= 4 failed, 153 passed, 3 warnings in 57.00s ========================================

(rapids) root@3afe3038599f:/workspace/01_NVT/16_NewAPI_unit/NVTabular# pytest tests/unit/test_ops.py::test_hash_bucket_lists
=================================================== test session starts ===================================================
platform linux -- Python 3.7.8, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
benchmark: 3.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspace/01_NVT/16_NewAPI_unit/NVTabular, configfile: setup.cfg
plugins: asyncio-0.12.0, benchmark-3.2.3, timeout-1.4.2, hypothesis-5.37.4, cov-2.10.1
collected 1 item

tests/unit/test_ops.py .                                                                                            [100%]

==================================================== 1 passed in 1.22s ====================================================
(rapids) root@3afe3038599f:/workspace/01_NVT/16_NewAPI_unit/NVTabular#

(rapids) root@3afe3038599f:/workspace/01_NVT/16_NewAPI_unit/NVTabular# pytest tests/unit/test_ops.py::test_categorify_lists=================================================== test session starts ===================================================
platform linux -- Python 3.7.8, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
benchmark: 3.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspace/01_NVT/16_NewAPI_unit/NVTabular, configfile: setup.cfg
plugins: asyncio-0.12.0, benchmark-3.2.3, timeout-1.4.2, hypothesis-5.37.4, cov-2.10.1
collected 3 items

tests/unit/test_ops.py ...                                                                                          [100%]

==================================================== 3 passed in 2.72s ====================================================
(rapids) root@3afe3038599f:/workspace/01_NVT/16_NewAPI_unit/NVTabular#
```