### PR TITLE
Uses cudf 0.17

### DIFF
--- a/nvtabular/io/parquet.py
+++ b/nvtabular/io/parquet.py
@@ -135,9 +135,11 @@ class ParquetWriter(ThreadedWriter):
                 if self.bytes_io:
                     bio = BytesIO()
                     self.data_bios.append(bio)
-                    self.data_writers.append(pwriter(bio, compression=None))
+                    # Passing index=False when creating ParquetWriter
+                    # to avoid bug: https://github.com/rapidsai/cudf/issues/7011
+                    self.data_writers.append(pwriter(bio, compression=None, index=False))
                 else:
-                    self.data_writers.append(pwriter(path, compression=None))
+                    self.data_writers.append(pwriter(path, compression=None, index=False))
 
             return self.data_writers[idx]
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -94,7 +94,8 @@ def test_dask_dataset(datasets, engine, num_files):
         dataset = nvtabular.io.Dataset(paths, header=False, names=allcols_csv)
         result = dataset.to_ddf(columns=mycols_csv)
 
-    assert_eq(ddf0, result)
+    # We do not preserve the index in NVTabular
+    assert_eq(ddf0, result, check_index=False)
 
 
 @pytest.mark.parametrize("output_format", ["hugectr", "parquet"])

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -95,7 +95,10 @@ def test_dask_dataset(datasets, engine, num_files):
         result = dataset.to_ddf(columns=mycols_csv)
 
     # We do not preserve the index in NVTabular
-    assert_eq(ddf0, result, check_index=False)
+    if engine == "parquet":
+        assert_eq(ddf0, result, check_index=False)
+    else:
+        assert_eq(ddf0, result)
 
 
 @pytest.mark.parametrize("output_format", ["hugectr", "parquet"])

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -640,16 +640,16 @@ def test_difference_lag():
     processor.fit(dataset)
     new_gdf = processor.transform(dataset).to_ddf().compute()
 
-    assert new_gdf["timestamp_difference_lag_1"][0] is None
+    assert new_gdf["timestamp_difference_lag_1"][0] is cudf.NA
     assert new_gdf["timestamp_difference_lag_1"][1] == 5
     assert new_gdf["timestamp_difference_lag_1"][2] == 95
-    assert new_gdf["timestamp_difference_lag_1"][3] is None
+    assert new_gdf["timestamp_difference_lag_1"][3] is cudf.NA
 
     assert new_gdf["timestamp_difference_lag_-1"][0] == -5
     assert new_gdf["timestamp_difference_lag_-1"][1] == -95
-    assert new_gdf["timestamp_difference_lag_-1"][2] is None
+    assert new_gdf["timestamp_difference_lag_-1"][2] is cudf.NA
     assert new_gdf["timestamp_difference_lag_-1"][3] == -1
-    assert new_gdf["timestamp_difference_lag_-1"][5] is None
+    assert new_gdf["timestamp_difference_lag_-1"][5] is cudf.NA
 
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -657,16 +657,16 @@ def test_difference_lag():
     processor.fit(dataset)
     new_gdf = processor.transform(dataset).to_ddf().compute()
 
-    assert new_gdf["timestamp_difference_lag_1"][0] is cudf.NA
+    assert new_gdf["timestamp_difference_lag_1"][0] is (cudf.NA if hasattr(cudf, "NA") else None)
     assert new_gdf["timestamp_difference_lag_1"][1] == 5
     assert new_gdf["timestamp_difference_lag_1"][2] == 95
-    assert new_gdf["timestamp_difference_lag_1"][3] is cudf.NA
+    assert new_gdf["timestamp_difference_lag_1"][3] is (cudf.NA if hasattr(cudf, "NA") else None)
 
     assert new_gdf["timestamp_difference_lag_-1"][0] == -5
     assert new_gdf["timestamp_difference_lag_-1"][1] == -95
-    assert new_gdf["timestamp_difference_lag_-1"][2] is cudf.NA
+    assert new_gdf["timestamp_difference_lag_-1"][2] is (cudf.NA if hasattr(cudf, "NA") else None)
     assert new_gdf["timestamp_difference_lag_-1"][3] == -1
-    assert new_gdf["timestamp_difference_lag_-1"][5] is cudf.NA
+    assert new_gdf["timestamp_difference_lag_-1"][5] is (cudf.NA if hasattr(cudf, "NA") else None)
 
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])


### PR DESCRIPTION
New PR after #494 was closed and cannot be reopened (new_api branch does not exist anymore).

@rjzamora for info.

Errors found when using cudf 0.17:

1. `KeyError: None` in `tests/unit/test_dask_nvt.py::test_dask_workflow_api_dlrm`
    - This is due to a Dask bug. @rjzamora  has already submitted a [PR](https://github.com/dask/dask/pull/6969); and until we update to the next Dask version as a work around we can just avoid the flag `index=False` in NVTabular

2. `AssertionError: DataFrame.index` are different in `tests/unit/test_io.py::test_dask_dataset`
    - This error is happening when reading multiple parquet files. Trying to fix it adding the flag `check_index=False` since we don't care about matching indices in NVTabular. That solved the Parquet error, but creates errors for csv.

3. `assert <NA> is None` in `test_ops.py::test_difference_lag`
    - Having a frame with `dtype: bool`, we were doing the following operation `mask[mask == False] = None`. The resulting dataframe contains `<NA>` values instead of `None`. This is expected, cudf has stopped using None and instead is using `<NA>` to be coherent with pandas (`cudf.NA`).

4. `assert False` in `test_lamdaop`

5. `ValueError: Can only compare identically-labeled DataFrame` in `test_log` 

6. `RuntimeError: cuDF failure` in `test_normalize_minmax`, `test_fill_median`, and `test_normalize`
    - `RuntimeError: cuDF failure at: /opt/conda/envs/rapids/conda-bld/libcudf_1607613794356/work/cpp/src/binaryop/binaryop.cpp:695: Column sizes don't match`

 
**TODO: Fix errors**:
- [X] Fix `KeyError: None`
- [X] Fix `AssertionError: DataFrame.index`
- [X] Fix `assert <NA> is None`
- [X] Fix `assert False`
- [X] Fix `ValueError: Can only compare identically-labeled DataFrame`
- [X] Fix `RuntimeError: cuDF`