### PR TITLE
Workflow serialization

### DIFF
--- a/nvtabular/ops/data_stats.py
+++ b/nvtabular/ops/data_stats.py
@@ -93,12 +93,6 @@ class DataStats(StatOperator):
                     dask_stats[col]["cardinality"] = dask_stats[col]["cardinality"].item()
         self.output = dask_stats
 
-    def save(self):
-        return self.output
-
-    def load(self, data):
-        self.output = data
-
     def clear(self):
         self.output = {}
 

--- a/nvtabular/ops/fill.py
+++ b/nvtabular/ops/fill.py
@@ -94,11 +94,5 @@ class FillMedian(StatOperator):
     fit.__doc__ = StatOperator.fit.__doc__
     fit_finalize.__doc__ = StatOperator.fit_finalize.__doc__
 
-    def save(self):
-        return self.medians
-
-    def load(self, data):
-        self.medians = data
-
     def clear(self):
         self.medians = {}

--- a/nvtabular/ops/join_groupby.py
+++ b/nvtabular/ops/join_groupby.py
@@ -170,11 +170,9 @@ class JoinGroupby(StatOperator):
                         output.append(f"{name}_{cont}_{stat}")
         return output
 
-    def save(self):
-        return [self.categories, self.storage_name]
-
-    def load(self, stats):
-        self.categories, self.storage_name = stats
+    def set_storage_path(self, new_path, copy=False):
+        self.categories = nvt_cat._copy_storage(self.categories, self.out_path, new_path, copy)
+        self.out_path = new_path
 
     def clear(self):
         self.categories = {}

--- a/nvtabular/ops/normalize.py
+++ b/nvtabular/ops/normalize.py
@@ -65,13 +65,6 @@ class Normalize(StatOperator):
                 new_gdf[name] = new_gdf[name].astype("float32")
         return new_gdf
 
-    def save(self):
-        return {"means": self.means, "stds": self.stds}
-
-    def load(self, data):
-        self.means = data["means"]
-        self.stds = data["stds"]
-
     def clear(self):
         self.means = {}
         self.stds = {}
@@ -123,13 +116,6 @@ class NormalizeMinMax(StatOperator):
         for col in dask_stats["mins"].index.values_host:
             self.mins[col] = dask_stats["mins"][col]
             self.maxs[col] = dask_stats["maxs"][col]
-
-    def save(self):
-        return {"mins": self.mins, "maxs": self.maxs}
-
-    def load(self, data):
-        self.mins = data["mins"]
-        self.maxs = data["maxs"]
 
     def clear(self):
         self.mins = {}

--- a/nvtabular/ops/stat_operator.py
+++ b/nvtabular/ops/stat_operator.py
@@ -45,16 +45,15 @@ class StatOperator(Operator):
             """Follow-up operations to convert dask statistics in to member variables"""
         )
 
-    def save(self):
-        """Returns a json-able representation of the statistics for this object. This
-        is usually called by the workflow rather than diretly"""
-        raise NotImplementedError("save isn't implemented for this op!")
-
-    def load(self, data):
-        """Loads statistics from a json-able blob of data. This is usually called
-        by the workflow rather than called directly"""
-        raise NotImplementedError("load isn't implemented for this op!")
-
     def clear(self):
         """ zero and reinitialize all relevant statistical properties"""
         raise NotImplementedError("clear isn't implemented for this op!")
+
+    def set_storage_path(self, path, copy=False):
+        """Certain stat operators need external storage - for instance Categorify writes out
+        parquet files containing the categorical mapping. When we save the operator, we
+        also want to save these files as part of the bundle. Implementing this method
+        lets statoperators bundle their dependant files into the new path that we're writing
+        out (note that this could happen after the operator is created)
+        """
+        pass

--- a/nvtabular/ops/target_encoding.py
+++ b/nvtabular/ops/target_encoding.py
@@ -215,12 +215,9 @@ class TargetEncoding(StatOperator):
 
         return ret
 
-    def save(self):
-        return {"stats": self.stats, "means": self.means}
-
-    def load(self, data):
-        self.stats = data["stats"]
-        self.means = data["means"]
+    def set_storage_path(self, new_path, copy=False):
+        self.stats = nvt_cat._copy_storage(self.stats, self.out_path, new_path, copy)
+        self.out_path = new_path
 
     def clear(self):
         self.stats = {}

--- a/nvtabular/tools/dataset_inspector.py
+++ b/nvtabular/tools/dataset_inspector.py
@@ -70,15 +70,13 @@ class DatasetInspector:
         labels = columns_dict["labels"]
 
         # Create Dataset, Workflow, and get Stats
-        features = cats + conts + labels >> DataStats()
+        stats = DataStats()
+        features = cats + conts + labels >> stats
         workflow = Workflow(features, client=self.client)
         workflow.fit(dataset)
 
-        # Save stats in a file and read them back
-        stats_file = "stats_output.yaml"
-        workflow.save_stats(stats_file)
-        output = yaml.safe_load(open(stats_file))
-        output = output[1]["stats"]
+        # get statistics from the datastats op
+        output = stats.output
 
         # Dictionary to store collected information
         data = {}

--- a/nvtabular/tools/dataset_inspector.py
+++ b/nvtabular/tools/dataset_inspector.py
@@ -18,7 +18,6 @@ import json
 
 import fsspec
 import numpy as np
-import yaml
 
 from nvtabular.ops import DataStats
 from nvtabular.workflow import Workflow

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -19,6 +19,7 @@ import os
 import sys
 import time
 from typing import TYPE_CHECKING, Optional
+import warnings
 
 import cloudpickle
 import cudf
@@ -216,8 +217,10 @@ class Workflow:
         # check version information from the metadata blob, and warn if we have a mismatch
         meta = json.load(open(os.path.join(path, "metadata.json")))
 
+        def parse_version(version):
+            return version.split(".")[:2]
+
         def check_version(stored, current, name):
-            parse_version = lambda version: version.split(".")[:2]
             if parse_version(stored) != parse_version(current):
                 warnings.warn(
                     f"Loading workflow generated with {name} version {stored} "

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -18,8 +18,8 @@ import logging
 import os
 import sys
 import time
-from typing import TYPE_CHECKING, Optional
 import warnings
+from typing import TYPE_CHECKING, Optional
 
 import cloudpickle
 import cudf

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -21,7 +21,6 @@ import dask_cudf
 import numpy as np
 import pandas as pd
 import pytest
-import yaml
 from cudf.tests.utils import assert_eq
 from dask.dataframe import assert_eq as assert_eq_dd
 from pandas.api.types import is_integer_dtype

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -721,14 +721,15 @@ def test_data_stats(tmpdir, df, datasets, engine):
     all_cols = cat_names + cont_names + label_name
 
     dataset = nvtabular.Dataset(df, engine=engine)
-    features = all_cols >> ops.DataStats()
+
+    data_stats = ops.DataStats()
+
+    features = all_cols >> data_stats
     workflow = nvtabular.Workflow(features)
     workflow.fit(dataset)
-    # Save stats in a file and read them back
-    stats_file = "stats_output.yaml"
-    workflow.save_stats(stats_file)
-    output = yaml.safe_load(open(stats_file))
-    output = output[1]["stats"]
+
+    # get the output from the data_stats op
+    output = data_stats.output
 
     # Check Output
     ddf = dask_cudf.from_cudf(df, 2)

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -17,6 +17,7 @@
 import glob
 import math
 import os
+import shutil
 
 import cudf
 import numpy as np
@@ -51,11 +52,11 @@ def test_gpu_workflow_api(tmpdir, client, df, dataset, gpu_memory_frac, engine, 
     workflow.fit(dataset)
 
     if dump:
-        # TODO: load/save stats
-        config_file = tmpdir + "/temp.yaml"
-        workflow.save_stats(config_file)
-        workflow.clear_stats()
-        workflow.load_stats(config_file)
+        workflow_dir = os.path.join(tmpdir, "workflow")
+        workflow.save(workflow_dir)
+        workflow = None
+
+        workflow = Workflow.load(workflow_dir, client=client if use_client else None)
 
     def get_norms(tar: cudf.Series):
         gdf = tar.fillna(0)
@@ -128,7 +129,7 @@ def test_spec_set(tmpdir, client):
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])
 @pytest.mark.parametrize("engine", ["parquet", "csv", "csv-no-header"])
 @pytest.mark.parametrize("dump", [True, False])
-def test_gpu_workflow(tmpdir, client, df, dataset, gpu_memory_frac, engine, dump):
+def test_gpu_workflow(tmpdir, df, dataset, gpu_memory_frac, engine, dump):
     cat_names = ["name-cat", "name-string"] if engine == "parquet" else ["name-string"]
     cont_names = ["x", "y", "id"]
     label_name = ["label"]
@@ -140,11 +141,11 @@ def test_gpu_workflow(tmpdir, client, df, dataset, gpu_memory_frac, engine, dump
 
     workflow.fit(dataset)
     if dump:
-        # TODO: serialization
-        config_file = tmpdir + "/temp.yaml"
-        workflow.save_stats(config_file)
-        workflow.clear_stats()
-        workflow.load_stats(config_file)
+        workflow_dir = os.path.join(tmpdir, "workflow")
+        workflow.save(workflow_dir)
+        workflow = None
+
+        workflow = Workflow.load(workflow_dir)
 
     def get_norms(tar: cudf.Series):
         gdf = tar.fillna(0)
@@ -211,10 +212,11 @@ def test_gpu_workflow_config(tmpdir, client, df, dataset, gpu_memory_frac, engin
     workflow.fit(dataset)
 
     if dump:
-        config_file = tmpdir + "/temp.yaml"
-        workflow.save_stats(config_file)
-        workflow.clear_stats()
-        workflow.load_stats(config_file)
+        workflow_dir = os.path.join(tmpdir, "workflow")
+        workflow.save(workflow_dir)
+        workflow = None
+
+        workflow = Workflow.load(workflow_dir, client=client)
 
     def get_norms(tar: cudf.Series):
         ser_median = tar.dropna().quantile(0.5, interpolation="linear")
@@ -520,6 +522,19 @@ def test_workflow_generate_columns(tmpdir, use_parquet):
     workflow.transform(dataset).to_parquet(out_path)
 
 
+def test_fit_simple():
+    data = cudf.DataFrame({"x": [0, 1, 2, None, 0, 1, 2], "y": [None, 3, 4, 5, 3, 4, 5]})
+    dataset = Dataset(data)
+
+    workflow = Workflow(["x", "y"] >> ops.FillMedian() >> (lambda x: x * x))
+
+    workflow.fit(dataset)
+    transformed = workflow.transform(dataset).to_ddf().compute()
+
+    expected = cudf.DataFrame({"x": [0, 1, 4, 1, 0, 1, 4], "y": [16, 9, 16, 25, 9, 16, 25]})
+    assert_eq(expected, transformed)
+
+
 def test_transform_geolocation():
     raw = """US>SC>519 US>CA>807 US>MI>505 US>CA>510 CA>NB US>CA>534""".split()
     data = cudf.DataFrame({"geo_location": raw})
@@ -540,14 +555,28 @@ def test_transform_geolocation():
     assert_eq(expected, transformed)
 
 
-def test_fit_simple():
-    data = cudf.DataFrame({"x": [0, 1, 2, None, 0, 1, 2], "y": [None, 3, 4, 5, 3, 4, 5]})
-    dataset = Dataset(data)
+def test_workflow_move_saved(tmpdir):
+    raw = """US>SC>519 US>CA>807 US>MI>505 US>CA>510 CA>NB US>CA>534""".split()
+    data = cudf.DataFrame({"geo_location": raw})
 
-    workflow = Workflow(["x", "y"] >> ops.FillMedian() >> (lambda x: x * x))
+    geo_location = ColumnGroup(["geo_location"])
+    state = geo_location >> (lambda col: col.str.slice(0, 5)) >> ops.Rename(postfix="_state")
+    country = geo_location >> (lambda col: col.str.slice(0, 2)) >> ops.Rename(postfix="_country")
+    geo_features = state + country + geo_location >> ops.Categorify()
 
-    workflow.fit(dataset)
-    transformed = workflow.transform(dataset).to_ddf().compute()
+    # create the workflow and transform the input
+    workflow = Workflow(geo_features)
+    expected = workflow.fit_transform(Dataset(data)).to_ddf().compute()
 
-    expected = cudf.DataFrame({"x": [0, 1, 4, 1, 0, 1, 4], "y": [16, 9, 16, 25, 9, 16, 25]})
+    # save the workflow (including categorical mapping parquet files)
+    # and then verify we can load the saved workflow after moving the directory
+    out_path = os.path.join(tmpdir, "output", "workflow")
+    workflow.save(out_path)
+
+    moved_path = os.path.join(tmpdir, "output", "workflow2")
+    shutil.move(out_path, moved_path)
+    workflow2 = Workflow.load(moved_path)
+
+    # also check that when transforming our input we get the same results after loading
+    transformed = workflow2.transform(Dataset(data)).to_ddf().compute()
     assert_eq(expected, transformed)


### PR DESCRIPTION
The existing load_stats/save_stats code only saved the calculated statistics for a workflow, but
didn't save all the operators that were used as well as the processing graph. This makes it
difficult to recreate the workflow exactly for cases like inferences

This PR adds support for saving and loading the entire workflow object. Since the operators
being applied could use lambdas or be custom operators written in jupyter notebooks - we're
using cloudpickle for serialization (cloudpickle is also used by dask).