### PR TITLE
Remove warnings when running unittests

### DIFF
--- a/nvtabular/tools/data_gen.py
+++ b/nvtabular/tools/data_gen.py
@@ -279,7 +279,7 @@ class DatasetGen:
 
     def get_batch(self, row_size):
         # grab max amount of gpu memory
-        gpu_mem = device_mem_size(kind="free") * self.gpu_frac
+        gpu_mem = device_mem_size(kind="total") * self.gpu_frac
         # find # of rows fit in gpu memory
         return gpu_mem // row_size
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ per-file-ignores =
 [tool:pytest]
 filterwarnings =
     ignore:WARNING..cuDF.to_dlpack
+    ignore:::numba.cuda.envvar:
+    ignore:.*The default dtype for empty Series will be.*:DeprecationWarning:cudf.core.dataframe:
 
 [versioneer]
 VCS = git

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,9 +67,11 @@ _CUDA_CLUSTER = None
 
 @pytest.fixture(scope="module")
 def client():
-    client = Client(LocalCluster(n_workers=2))
+    cluster = LocalCluster(n_workers=2)
+    client = Client(cluster)
     yield client
     client.close()
+    cluster.close()
 
 
 @contextlib.contextmanager

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -375,7 +375,6 @@ def test_validate_dataset(datasets, engine):
             assert not dataset.validate_dataset()
 
 
-
 def test_validate_dataset_bad_schema(tmpdir):
     if LooseVersion(dask.__version__) <= "2.30.0":
         # Older versions of Dask will not handle schema mismatch

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -18,8 +18,8 @@ import glob
 import json
 import math
 import os
-from distutils.version import LooseVersion
 import warnings
+from distutils.version import LooseVersion
 
 import cudf
 import dask

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -19,6 +19,7 @@ import json
 import math
 import os
 from distutils.version import LooseVersion
+import warnings
 
 import cudf
 import dask
@@ -358,18 +359,21 @@ def test_avro_basic(tmpdir, part_size, size, nfiles):
 
 @pytest.mark.parametrize("engine", ["csv", "parquet"])
 def test_validate_dataset(datasets, engine):
-    paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
-    if engine == "parquet":
-        dataset = nvtabular.io.Dataset(str(datasets[engine]), engine=engine)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
+        if engine == "parquet":
+            dataset = nvtabular.io.Dataset(str(datasets[engine]), engine=engine)
 
-        # Default file_min_size should result in failed validation
-        assert not dataset.validate_dataset()
-        assert dataset.validate_dataset(file_min_size=1, require_metadata_file=False)
-    else:
-        dataset = nvtabular.io.Dataset(paths, header=False, names=allcols_csv)
+            # Default file_min_size should result in failed validation
+            assert not dataset.validate_dataset()
+            assert dataset.validate_dataset(file_min_size=1, require_metadata_file=False)
+        else:
+            dataset = nvtabular.io.Dataset(paths, header=False, names=allcols_csv)
 
-        # CSV format should always fail validation
-        assert not dataset.validate_dataset()
+            # CSV format should always fail validation
+            assert not dataset.validate_dataset()
+
 
 
 def test_validate_dataset_bad_schema(tmpdir):


### PR DESCRIPTION
When running our unittests, we get a bunch of warnings saying things like

*  Port 8787 is already in use. Perhaps you already have a cluster running?
*  DeprecationWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. 
*  Environment variables with the 'NUMBAPRO' prefix are deprecated and consequently ignored,
etc

Clean these all up - either by cleaning up the root cause or by adding to the setup.cfg pytest warnings filter where that isn't possible.