### PR TITLE
Perfomance improvments for triton python poc

### DIFF
--- a/nvtabular/column_group.py
+++ b/nvtabular/column_group.py
@@ -240,7 +240,7 @@ def _merge_add_nodes(graph):
     # lets take a copy to avoid mutating the input
     import copy
 
-    graph = copy.deepcopy(graph)
+    graph = copy.copy(graph)
 
     queue = [graph]
     while queue:

--- a/nvtabular/inference/triton/model.py
+++ b/nvtabular/inference/triton/model.py
@@ -62,7 +62,9 @@ class TritonPythonModel:
             )
 
             # use our NVTabular workflow to transform the dataframe
-            output_df = self.workflow.transform(nvtabular.Dataset(input_df)).to_ddf().compute()
+            output_df = nvtabular.workflow._transform_partition(
+                input_df, [self.workflow.column_group]
+            )
 
             # convert back to a triton response
             response = InferenceResponse(

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -26,7 +26,7 @@ import cudf
 import dask
 from dask.core import flatten
 
-from nvtabular.column_group import ColumnGroup, iter_nodes
+from nvtabular.column_group import ColumnGroup, _merge_add_nodes, iter_nodes
 from nvtabular.io.dataset import Dataset
 from nvtabular.ops import StatOperator
 from nvtabular.worker import clean_worker_cache
@@ -68,7 +68,7 @@ class Workflow:
     """
 
     def __init__(self, column_group: ColumnGroup, client: Optional["distributed.Client"] = None):
-        self.column_group = column_group
+        self.column_group = _merge_add_nodes(column_group)
         self.client = client
         self.input_dtypes = None
         self.output_dtypes = None
@@ -204,7 +204,7 @@ class Workflow:
 
         # dump out the full workflow (graph/stats/operators etc) using cloudpickle
         with open(os.path.join(path, "workflow.pkl"), "wb") as o:
-            cloudpickle.dump(self.column_group, o)
+            cloudpickle.dump(self, o)
 
     @classmethod
     def load(cls, path, client=None):
@@ -245,14 +245,19 @@ class Workflow:
         check_version(versions["python"], sys.version, "python")
 
         # load up the workflow object di
-        column_group = cloudpickle.load(open(os.path.join(path, "workflow.pkl"), "rb"))
+        workflow = cloudpickle.load(open(os.path.join(path, "workflow.pkl"), "rb"))
+        workflow.client = client
 
         # we might have been copied since saving, update all the stat ops
         # with the new path to their storage locations
-        for stat in _get_stat_ops([column_group]):
+        for stat in _get_stat_ops([workflow.column_group]):
             stat.op.set_storage_path(path, copy=False)
 
-        return cls(column_group, client)
+        return workflow
+
+    def __getstate__(self):
+        # dask client objects aren't picklable - exclude from saved representation
+        return {k: v for k, v in self.__dict__.items() if k != "client"}
 
     def clear_stats(self):
         for stat in _get_stat_ops([self.column_group]):
@@ -292,15 +297,17 @@ def _get_stat_ops(nodes):
 
 def _transform_partition(root_gdf, column_groups):
     """ Transforms a single partition by appyling all operators in a ColumnGroup """
-    output = cudf.DataFrame()
+    output = None
     for column_group in column_groups:
         # collect dependencies recursively if we have parents
         if column_group.parents:
-            gdf = cudf.DataFrame()
+            gdf = None
             for parent in column_group.parents:
                 parent_gdf = _transform_partition(root_gdf, [parent])
-                for column in parent.flattened_columns:
-                    gdf[column] = parent_gdf[column]
+                if not gdf:
+                    gdf = parent_gdf[parent.flattened_columns]
+                else:
+                    gdf = cudf.concat([gdf, parent_gdf[parent.flattened_columns]], axis=1)
         else:
             # otherwise select the input from the root gdf
             gdf = root_gdf[column_group.flattened_columns]
@@ -320,11 +327,9 @@ def _transform_partition(root_gdf, column_groups):
         # dask needs output to be in the same order defined as meta, reorder partitions here
         # this also selects columns (handling the case of removing columns from the output using
         # "-" overload)
-        for column in column_group.flattened_columns:
-            if column not in gdf:
-                raise ValueError(
-                    f"Failed to find {column} in output of {column_group}, which"
-                    f" has columns {gdf.columns}"
-                )
-            output[column] = gdf[column]
+        if not output:
+            output = gdf[column_group.flattened_columns]
+        else:
+            output = cudf.concat([output, gdf[column_group.flattened_columns]], axis=1)
+
     return output


### PR DESCRIPTION
* Don't use a dask dataframe, call _transform_partition on a single dataframe instead
* Don't copy individual columns inside _transform_partition, instead select from the dataframe
* call '_merge_add_nodes' to (slightly) optimize the execution graph

With this changes the time to process a small batch of the rossmann dataset (with a hashbucket op
instead of categorify) is reduce from ~40ms to ~20ms.  Of this 20ms, about 75% is spent in
operators and the rest (5ms) is spent in remaining workflow overhead.

Also fix issue with serializing workflows - so that we continue to keep the input/output dtypes.
Instead of only serializing the columngroup, serialize the entire workflow but exclude the
dask client

