### PR TITLE
Skip test_parquet_lists on the CI machine

### DIFF
--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -356,7 +356,7 @@ def test_parquet_lists(tmpdir, freq_threshold, shuffle, out_files_per_proc):
     # to run this test frequently, whereas it works with later versions of cudf.
     # skip if we are running this specific version of cudf (and lets remove this
     # check entirely after we've upgraded the CI container)
-    if cudf.__version__.startswith("0+untagged.1.ga6296e3"):
+    if cudf.__version__.startswith("0+untagged"):
         pytest.skip("parquet lists support is flakey here without cudf0.18")
 
     df = cudf.DataFrame(

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -351,6 +351,14 @@ def test_multifile_parquet(tmpdir, dataset, df, engine, num_io_threads, nfiles, 
 @pytest.mark.parametrize("shuffle", [nvt.io.Shuffle.PER_PARTITION, None])
 @pytest.mark.parametrize("out_files_per_proc", [None, 2])
 def test_parquet_lists(tmpdir, freq_threshold, shuffle, out_files_per_proc):
+    # the cudf 0.17 dev container returns a '0+untagged.1.ga6296e3' version for cudf
+    # (which is tough to parse correctly with LooseVersion et al). This also fails
+    # to run this test frequently, whereas it works with later versions of cudf.
+    # skip if we are running this specific version of cudf (and lets remove this
+    # check entirely after we've upgraded the CI container)
+    if cudf.__version__.startswith("0+untagged.1.ga6296e3"):
+        pytest.skip("parquet lists support is flakey here without cudf0.18")
+
     df = cudf.DataFrame(
         {
             "Authors": [["User_A"], ["User_A", "User_E"], ["User_B", "User_C"], ["User_C"]],


### PR DESCRIPTION
This test is frequently failling due to our CI container being based off of cudf 0.17. Change to
skip this test until we can get cudf 0.18 on the container

