### PR TITLE
Fix broken links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ root@2efa5b50b909:
 
 4. Once in the server, navigate to the ```/nvtabular/``` directory and explore the code base or try out some of the examples.
 
-   The container contains the codebase along with all of our dependencies, particularly [RAPIDS Dask-cuDF](https://github.com/rapidsai/cudf/tree/main/python/dask_cudf) and a range of [examples](./examples). The easiest way to get started is to simply launch the container and explore the examples within it. The code base and related examples can be found at the following directory location within the container:
+   The container contains the codebase along with all of our dependencies, particularly [RAPIDS Dask-cuDF](https://github.com/rapidsai/cudf/tree/main/python/dask_cudf) and a range of [examples](./examples/). The easiest way to get started is to simply launch the container and explore the examples within it. The code base and related examples can be found at the following directory location within the container:
    ```
    /nvtabular/
    ```
@@ -116,6 +116,7 @@ With NVTabular running on a single V100 32GB GPU, we were able to complete ETL i
     
 ### Feedback and Support
 
-If you'd like to contribute to the library directly, please see the [Contributing.md](./CONTRIBUTING.md). We're particularly interested in contributions or feature requests for our feature engineering and preprocessing operations. To further advance our Merlin Roadmap, we encourage you to share all the details regarding your recommender system pipeline using this [this survey](https://developer.nvidia.com/merlin-devzone-survey).
+If you'd like to contribute to the library directly, please see the [Contributing.md](https://github.com/NVIDIA/NVTabular/blob/main/CONTRIBUTING.md). We're particularly interested in contributions or feature requests for our feature engineering and preprocessing operations. To further advance our Merlin Roadmap, we encourage you to share all the details regarding your recommender system pipeline using this [this survey](https://developer.nvidia.com/merlin-devzone-survey).
 
-If you're interested in learning more about how NVTabular works under the hood, see [Architecture](/docs/source/resources/architecture.md). We also have [API documentation](https://nvidia.github.io/NVTabular/main/resources/api/index.html) that outlines the specifics of the available calls within the library.
+If you're interested in learning more about how NVTabular works under the hood, see
+[Architecture](./docs/source/resources/architecture.md). We also have [API documentation](https://nvidia.github.io/NVTabular/main/resources/api/index.html) that outlines the specifics of the available calls within the library.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,14 +11,17 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import re
 import sys
+import warnings
 
-import sphinx
-import sphinx.domains
+from docutils import nodes
 from recommonmark.parser import CommonMarkParser
+from sphinx.errors import SphinxError
 
 rootdir = os.path.join(os.getenv("SPHINX_MULTIVERSION_SOURCEDIR", default="."), "..")
 sys.path.insert(0, rootdir)
+docs_dir = os.path.dirname(__file__)
 
 
 # -- Project information -----------------------------------------------------
@@ -83,30 +86,144 @@ smv_branch_whitelist = "^main$"
 
 html_sidebars = {"**": ["versions.html"]}
 
-# certain references in the README couldn't be autoresolved here,
-# hack by forcing to the either the correct documentation page (examples)
-# or to a blob on the repo
-_REPO = "https://github.com/NVIDIA/NVTabular/blob/main/"
-_URL_MAP = {
-    "./examples": "examples/index",
-    "examples/rossmann/": "examples/rossmann/index",
-    "examples/criteo-example.ipynb": "examples/criteo",
-    "./CONTRIBUTING": _REPO + "/CONTRIBUTING.md",
-    "./Operators": _REPO + "/Operators.md",
-}
-
-
-class GitHubDomain(sphinx.domains.Domain):
-    def resolve_any_xref(self, env, docname, builder, target, node, contnode):
-        resolved = _URL_MAP.get(target)
-        if resolved:
-            contnode["refuri"] = resolved
-            return [("github:any", contnode)]
-        return []
-
 
 def setup(app):
-    app.add_domain(GitHubDomain)
+    # Fixing how references (local links) work with Markdown
+    app.connect("doctree-read", collect_ref_data)
+    app.connect("doctree-resolved", process_refs)
+
+
+# Adapted from
+# https://github.com/apiaryio/dredd/blob/a0e999d69ee840778de191fd03acbdeda86e27e2/docs/conf.py#L172:L285  # noqa
+# (released under the MIT license)
+# -- Markdown References --------------------------------------------------
+
+
+def collect_ref_data(app, doctree):
+    """
+    Finds all anchors and references (local links) within documents,
+    and saves them as meta data
+    """
+    filename = doctree.attributes["source"]
+
+    # this needs to happen to make this work with sphinx-multiversion
+    metadata = app.config.smv_metadata or {}
+    current_version = app.config.smv_current_version
+    if metadata and current_version:
+        sourcedir = metadata.get(current_version, {}).get("sourcedir")
+        if sourcedir and filename.startswith(sourcedir):
+            filename = filename[len(sourcedir) :]
+
+    # otherwise lets just split off the current directory (not sphinx multiversion)
+    filename = filename.replace(docs_dir, "").lstrip("/")
+    docname = filename.replace(".md", "")
+
+    anchors = []
+    references = []
+
+    for node in doctree.traverse(nodes.raw):
+        if "name=" in node.rawsource:
+            match = re.search(r'name="([^\"]+)', node.rawsource)
+            if match:
+                anchors.append(match.group(1))
+        elif "id=" in node.rawsource:
+            match = re.search(r'id="([^\"]+)', node.rawsource)
+            if match:
+                anchors.append(match.group(1))
+
+    for node in doctree.traverse(nodes.section):
+        for target in frozenset(node.attributes.get("ids", [])):
+            anchors.append(target)
+
+    for node in doctree.traverse(nodes.reference):
+        uri = node.get("refuri")
+        if uri and not uri.startswith(("http://", "https://")):
+            ref = to_reference(uri, basedoc=docname)
+            references.append(ref)
+
+    app.env.metadata[docname]["anchors"] = anchors
+    app.env.metadata[docname]["references"] = references
+
+
+def process_refs(app, doctree, docname):
+    """
+    Fixes all references (local links) within documents, breaks the build
+    if it finds any links to non-existent documents or anchors.
+    """
+    references = app.env.metadata[docname].get("references", [])
+    if not references:
+        return
+
+    for reference in references:
+        referenced_docname, anchor = parse_reference(reference)
+
+        if referenced_docname not in app.env.metadata:
+            message = "Document '{}' is referenced from '{}', but it could not be found"
+            warnings.warn(message.format(referenced_docname, docname))
+            continue
+
+        if anchor and anchor not in app.env.metadata[referenced_docname]["anchors"]:
+            message = "Section '{}#{}' is referenced from '{}', but it could not be found"
+            raise SphinxError(message.format(referenced_docname, anchor, docname))
+        for node in doctree.traverse(nodes.reference):
+            uri = node.get("refuri")
+            if to_reference(uri, basedoc=docname) == reference:
+                node["refuri"] = to_uri(app, referenced_docname, anchor)
+
+
+def to_uri(app, docname, anchor=None):
+    uri = ""
+    smv_current_version = app.config.smv_current_version
+    if smv_current_version:
+        uri = "/{}".format(smv_current_version)
+
+    uri += "/{}.html".format(docname)
+    if anchor:
+        uri += "#{}".format(anchor)
+
+    return uri
+
+
+def to_reference(uri, basedoc=None):
+    """
+    Helper function, compiles a 'reference' from given URI and base
+    document name
+    """
+    if "#" in uri:
+        filename, anchor = uri.split("#", 1)
+        filename = filename or basedoc
+    else:
+        filename = uri or basedoc
+        anchor = None
+
+    if not filename:
+        message = "For self references like '{}' you need to provide the 'basedoc' argument".format(
+            uri
+        )
+        raise ValueError(message)
+
+    prefixes = ["docs/source/", "./docs/source/"]
+    for prefix in prefixes:
+        if filename.startswith(prefix):
+            filename = filename[len(prefix) :]
+
+    reference = os.path.splitext(filename.lstrip("/"))[0]
+    if anchor:
+        reference += "#" + anchor
+
+    return reference
+
+
+def parse_reference(reference):
+    """
+    Helper function, parses a 'reference' to document name and anchor
+    """
+    if "#" in reference:
+        docname, anchor = reference.split("#", 1)
+    else:
+        docname = reference
+        anchor = None
+    return docname, anchor
 
 
 intersphinx_mapping = {
@@ -114,7 +231,6 @@ intersphinx_mapping = {
     "cudf": ("https://docs.rapids.ai/api/cudf/stable/", None),
     "distributed": ("https://distributed.dask.org/en/latest/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
-    "tensorflow": ("https://www.tensorflow.org/api_docs/python", None),
 }
 
 autodoc_inherit_docstrings = False

--- a/docs/source/core_features.md
+++ b/docs/source/core_features.md
@@ -71,4 +71,4 @@ NVTabular makes it possible to shuffle during dataset creation. This creates a u
 
 ## Cloud Integration ##
 
-NVTabular offers cloud integration with Amazon Web Services (AWS) and Google Cloud Platform (GCP), giving you the ability to build, train, and deploy models on the cloud using datasets. For additional information, see [Amazon Web Services](../docs/source/cloud_integration.md#amazon-web-services) and [Google Cloud Platform](../docs/source/cloud_integration.md#google-cloud-platform).
+NVTabular offers cloud integration with Amazon Web Services (AWS) and Google Cloud Platform (GCP), giving you the ability to build, train, and deploy models on the cloud using datasets. For additional information, see [Amazon Web Services](./resources/cloud_integration.md#amazon-web-services) and [Google Cloud Platform](./resources/cloud_integration.md#google-cloud-platform).

--- a/docs/source/examples/advanced-ops-outbrain/index.rst
+++ b/docs/source/examples/advanced-ops-outbrain/index.rst
@@ -1,5 +1,5 @@
-Advanced Operators - Outbrain
-=============================
+Advanced Ops with Outbrain
+==========================
 
 `Outbrain dataset <https://www.kaggle.com/c/outbrain-click-prediction>`_ is based on a Kaggle Competition in which Kagglers were challenged to predict on which ads and other forms of sponsored content its global users would click. We will teach to use more of the available NVTabular operators:
 

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -3,7 +3,7 @@ Examples
 
 
 We created a collection of Jupyter notebooks based on different datasets. The examples cover how
-to use NVTabular in combination with TensorFlow, PyTorch and `HugeCTR https://github.com/NVIDIA/HugeCTR`_
+to use NVTabular in combination with TensorFlow, PyTorch and `HugeCTR <https://github.com/NVIDIA/HugeCTR>`_ .
 Each example explains some features of NVTabular in detail. We provide an order to go through the notebooks 
 as the later ones expect some prior knowledge.
 
@@ -11,9 +11,9 @@ as the later ones expect some prior knowledge.
 .. toctree::
    :maxdepth: 1
     
-   Getting Started - MovieLens <getting-started-movielens/index>
-   Advanced Operators - Outbrain <advanced-ops-outbrain/index>
-   Scaling - Criteo <scaling-criteo/index>
-   Winning Solution RecSys2020 - Twitter <winning-solution-recsys2020-twitter/01-02-04-Download-Convert-ETL-with-NVTabular-Training-with-XGBoost>
-   Tabular Data - Rossmann <tabular-data-rossmann/index>
+   Getting Started with Movielens <getting-started-movielens/index>
+   Advanced Ops with Outbrain <advanced-ops-outbrain/index>
+   Scaling to Large Datasets with Criteo <scaling-criteo/index>
+   Winning Solution of the RecSys2020 Competition <winning-solution-recsys2020-twitter/01-02-04-Download-Convert-ETL-with-NVTabular-Training-with-XGBoost>
+   Tabular Data with Rossmann <tabular-data-rossmann/index>
    Multi-GPU Example <multi-gpu-toy-example/multi-gpu_dask>

--- a/docs/source/examples/scaling-criteo/index.rst
+++ b/docs/source/examples/scaling-criteo/index.rst
@@ -1,5 +1,5 @@
-Scaling - Criteo
-================
+Scaling to Large Datasets with Criteo
+=====================================
 
 `Criteo <https://ailab.criteo.com/download-criteo-1tb-click-logs-dataset/>`_ provides the largest publicly available dataset for recommender systems, having a size of 1TB uncompressed click logs of 4 billion examples. We will teach to scale NVTabular:
 

--- a/docs/source/resources/index.rst
+++ b/docs/source/resources/index.rst
@@ -1,5 +1,5 @@
 Additional Resources
-===================
+====================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/training/pytorch.md
+++ b/docs/source/training/pytorch.md
@@ -61,4 +61,5 @@ When `TorchAsyncItr` accelerates training with PyTorch, the following happens:
 
 5. The `TorchAsyncItr` dataloader can be initialized for the validation dataset using the same structure.  
 
-You can find additional examples in our repository such as [MovieLens](../examples/movielens_multihot_example.ipynb) and [Criteo](../examples/criteo-example.ipynb).
+You can find additional examples in our repository such as [MovieLens](../examples/getting-started-movielens/) and [Criteo](
+../examples/scaling-criteo/).

--- a/docs/source/training/tensorflow.md
+++ b/docs/source/training/tensorflow.md
@@ -86,4 +86,4 @@ When `KerasSequenceLoader` accelerates training with TensorFlow, the following h
    history = model.fit(train_dataset_tf, callbacks=[validation_callback], epochs=5)
    ```
 
-You can find additional examples in our repository such as [MovieLens](../examples/movielens_multihot_example.ipynb) and [Outbrain](../examples/wnd_outbrain/Outbrain.ipynb).
+You can find additional examples in our repository such as [MovieLens](../examples/getting-started-movielens/) and [Outbrain](../examples/advanced-ops-outbrain/).


### PR DESCRIPTION
Move towards a more advanced method of resolving urls within markdown files,
using sphinx doctree-read and doctree-resolved hooks. The tricky part here
is making this aware of the sphinx multiversion extension - and having
the generated urls work as appropriate.

This lets us just mention 'docs/source/core_features.md' in the README
and have it work both when rendered by github and when rendered in our
sphinx docs.

Also fix some other minor documentation issues
