### PR TITLE
Avoid full map_partitions for list-dtype query

### DIFF
--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -320,8 +320,8 @@ class Categorify(StatOperator):
             num_buckets=self.num_buckets,
         )
         # TODO: we can't check the dtypes on the ddf here since they are incorrect
-        # for cudf's list type. So, we're checking the partitions. fix.
-        return Delayed(key, dsk), ddf.map_partitions(lambda df: _is_list_dtype(df))
+        # for cudf's list type. So, we're checking the frist partition. fix.
+        return Delayed(key, dsk), ddf.partitions[0].map_partitions(lambda df: _is_list_dtype(df))
 
     def fit_finalize(self, dask_stats):
         _col_is_list = dask_stats[1]

--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -320,7 +320,7 @@ class Categorify(StatOperator):
             num_buckets=self.num_buckets,
         )
         # TODO: we can't check the dtypes on the ddf here since they are incorrect
-        # for cudf's list type. So, we're checking the frist partition. fix.
+        # for cudf's list type. So, we're checking the first partition. fix.
         return Delayed(key, dsk), ddf.partitions[0].map_partitions(lambda df: _is_list_dtype(df))
 
     def fit_finalize(self, dask_stats):


### PR DESCRIPTION
While running the `dask-nvtabular-criteo-benchmark.py` benchmark today, I noticed that the performance degraded dramatically after the API overhaul.  More specifically, the default settings do not even work for a DGX-1 machine with 8x32GB-V100 GPUs.  As far as I can tell, the problem is caused by the new `map_partitions` call in `Categorify`.  This operation is checking every partition to see if there are list-column dtypes, when it is probably sufficient to check a single partition.  This PR changes the problematic `map_partitions` operation to target the first partition only (which seems to be much faster, and results in significantly less spilling).

<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
