### PR TITLE
Allow transformed columns in JoinGroupby

### DIFF
--- a/examples/winning-solution-recsys2020-twitter/01-02-04-Download-Convert-ETL-with-NVTabular-Training-with-XGBoost.ipynb
+++ b/examples/winning-solution-recsys2020-twitter/01-02-04-Download-Convert-ETL-with-NVTabular-Training-with-XGBoost.ipynb
@@ -1051,7 +1051,7 @@
    "source": [
     "count_encode = (\n",
     "    ['media', 'tweet_type', 'language', 'a_user_id', 'b_user_id'] >> \n",
-    "    nvt.ops.JoinGroupby(cont_names=['reply'],stats=[\"count\"], out_path='./')\n",
+    "    nvt.ops.JoinGroupby(cont_cols=['reply'],stats=[\"count\"], out_path='./')\n",
     ")"
    ]
   },

--- a/nvtabular/ops/join_groupby.py
+++ b/nvtabular/ops/join_groupby.py
@@ -18,6 +18,7 @@ import cupy
 import dask_cudf
 from dask.delayed import Delayed
 
+import nvtabular as nvt
 from nvtabular.dispatch import _read_parquet_dispatch
 
 from . import categorify as nvt_cat
@@ -39,14 +40,14 @@ class JoinGroupby(StatOperator):
 
         # Use JoinGroupby to define a NVTabular workflow
         groupby_features = ['cat1', 'cat2', 'cat3'] >> ops.JoinGroupby(
-            out_path=str(tmpdir), stats=['sum','count'], cont_names=['num1']
+            out_path=str(tmpdir), stats=['sum','count'], cont_cols=['num1']
         )
         processor = nvtabular.Workflow(groupby_features)
 
     Parameters
     -----------
-    cont_names : list of str
-        The continuous column names to calculate statistics for
+    cont_cols : list of str or ColumnGroup
+        The continuous columns to calculate statistics for
         (for each unique group in each column in `columns`).
     stats : list of str, default []
         List of statistics to calculate for each unique group. Note
@@ -76,7 +77,7 @@ class JoinGroupby(StatOperator):
 
     def __init__(
         self,
-        cont_names=None,
+        cont_cols=None,
         stats=["count"],
         tree_width=None,
         cat_cache="host",
@@ -88,7 +89,10 @@ class JoinGroupby(StatOperator):
 
         self.storage_name = {}
         self.name_sep = name_sep
-        self.cont_names = cont_names
+        self.cont_cols = (
+            cont_cols if isinstance(cont_cols, nvt.ColumnGroup) else nvt.ColumnGroup(cont_cols)
+        )
+        self.cont_names = self.cont_cols.columns
         self.stats = stats
         self.tree_width = tree_width
         self.out_path = out_path or "./"
@@ -158,7 +162,7 @@ class JoinGroupby(StatOperator):
         return new_gdf
 
     def dependencies(self):
-        return self.cont_names
+        return self.cont_cols
 
     def output_column_names(self, columns):
         # TODO: the names here are defined in categorify/mid_level_groupby

--- a/tests/unit/test_dask_nvt.py
+++ b/tests/unit/test_dask_nvt.py
@@ -148,7 +148,7 @@ def test_dask_groupby_stats(client, tmpdir, datasets, part_mem_fraction):
     label_name = ["label"]
 
     features = cat_names >> ops.JoinGroupby(
-        cont_names=cont_names, stats=["count", "sum", "std", "min"], out_path=str(tmpdir)
+        cont_cols=cont_names, stats=["count", "sum", "std", "min"], out_path=str(tmpdir)
     )
 
     dataset = Dataset(paths, part_mem_fraction=part_mem_fraction)
@@ -186,7 +186,7 @@ def test_cats_and_groupby_stats(client, tmpdir, datasets, part_mem_fraction, use
     cats = ColumnGroup(cat_names)
     cat_features = cats >> ops.Categorify(out_path=str(tmpdir), freq_threshold=10, on_host=True)
     groupby_features = cats >> ops.JoinGroupby(
-        cont_names=cont_names, stats=["count", "sum"], out_path=str(tmpdir)
+        cont_cols=cont_names, stats=["count", "sum"], out_path=str(tmpdir)
     )
 
     workflow = Workflow(cat_features + groupby_features, client=client)

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -409,7 +409,7 @@ def test_chaining_3():
     )
 
     platform_features = ["platform"] >> ops.Dropna()
-    joined = ["ad_id"] >> ops.JoinGroupby(cont_names=["clicked"], stats=["sum", "count"])
+    joined = ["ad_id"] >> ops.JoinGroupby(cont_cols=["clicked"], stats=["sum", "count"])
     joined_lambda = (
         joined
         >> ops.LambdaOp(f=lambda col, gdf: col / gdf["ad_id_count"])


### PR DESCRIPTION
The JoinGroupby op previously could only handle calculating stats on 'cont_cols'
that were unchanged from the original dataset. This change makes it so that
you can use arbitrary columns - including ones that have had some transformations
applied already.

