### PR TITLE
Add suffix= argument to to_parquet (and writers)

### DIFF
--- a/examples/scaling-criteo/01-Download-Convert.ipynb
+++ b/examples/scaling-criteo/01-Download-Convert.ipynb
@@ -257,7 +257,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/examples/scaling-criteo/01-Download-Convert.ipynb
+++ b/examples/scaling-criteo/01-Download-Convert.ipynb
@@ -257,7 +257,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/nvtabular/io/dask.py
+++ b/nvtabular/io/dask.py
@@ -65,6 +65,7 @@ def _write_output_partition(
     output_format,
     num_threads,
     cpu,
+    suffix,
 ):
     df_size = len(df)
     out_files_per_proc = out_files_per_proc or 1
@@ -82,6 +83,7 @@ def _write_output_partition(
                 bytes_io=(shuffle == Shuffle.PER_WORKER),
                 num_threads=num_threads,
                 cpu=cpu,
+                suffix=suffix,
             )
             writer.set_col_names(labels=label_names, cats=cat_names, conts=cont_names)
             writer_cache[processed_path] = writer
@@ -105,6 +107,7 @@ def _write_subgraph(
     output_format,
     num_threads,
     cpu,
+    suffix,
 ):
 
     writer = writer_factory(
@@ -115,7 +118,7 @@ def _write_subgraph(
         bytes_io=(shuffle == Shuffle.PER_WORKER),
         num_threads=num_threads,
         cpu=cpu,
-        fns=[fn],
+        fns=[fn + suffix],
     )
     writer.set_col_names(labels=label_names, cats=cat_names, conts=cont_names)
 
@@ -164,6 +167,7 @@ def _ddf_to_dataset(
     client,
     num_threads,
     cpu,
+    suffix="",
 ):
 
     # Construct graph for Dask-based dataset write
@@ -197,6 +201,7 @@ def _ddf_to_dataset(
                 output_format,
                 num_threads,
                 cpu,
+                suffix,
             )
         dsk[name] = (
             _write_metadata_files,
@@ -222,6 +227,7 @@ def _ddf_to_dataset(
                 output_format,
                 num_threads,
                 cpu,
+                suffix,
             )
             task_list.append(key)
         dsk[name] = (lambda x: x, task_list)

--- a/nvtabular/io/hugectr.py
+++ b/nvtabular/io/hugectr.py
@@ -22,15 +22,17 @@ from .writer import ThreadedWriter
 
 
 class HugeCTRWriter(ThreadedWriter):
-    def __init__(self, out_dir, **kwargs):
+    def __init__(self, out_dir, suffix=".data", **kwargs):
         super().__init__(out_dir, **kwargs)
+        self.suffix = suffix
         if self.use_guid:
             self.data_paths = [
-                os.path.join(out_dir, f"{i}i.{uuid4().hex}.data") for i in range(self.num_out_files)
+                os.path.join(out_dir, f"{i}i.{uuid4().hex}{self.suffix}")
+                for i in range(self.num_out_files)
             ]
         else:
             self.data_paths = [
-                os.path.join(out_dir, f"{i}.data") for i in range(self.num_out_files)
+                os.path.join(out_dir, f"{i}{self.suffix}") for i in range(self.num_out_files)
             ]
         self.data_writers = [open(f, "wb") for f in self.data_paths]
         # Reserve 64 bytes for header

--- a/nvtabular/io/parquet.py
+++ b/nvtabular/io/parquet.py
@@ -655,7 +655,7 @@ def _write_data(data_list, output_path, fs, fn):
 
 
 class BaseParquetWriter(ThreadedWriter):
-    def __init__(self, out_dir, **kwargs):
+    def __init__(self, out_dir, suffix=".parquet", **kwargs):
         super().__init__(out_dir, **kwargs)
         self.data_paths = []
         self.data_files = []
@@ -664,6 +664,7 @@ class BaseParquetWriter(ThreadedWriter):
         self._lock = threading.RLock()
         self.pwriter = self._pwriter
         self.pwriter_kwargs = {}
+        self.suffix = suffix
 
     @property
     def _pwriter(self):
@@ -682,9 +683,9 @@ class BaseParquetWriter(ThreadedWriter):
         if self.fns:
             fn = self.fns[i]
         elif self.use_guid:
-            fn = f"{i}.{guid()}.parquet"
+            fn = f"{i}.{guid()}{self.suffix}"
         else:
-            fn = f"{i}.parquet"
+            fn = f"{i}{self.suffix}"
 
         return os.path.join(self.out_dir, fn)
 

--- a/nvtabular/io/writer.py
+++ b/nvtabular/io/writer.py
@@ -63,6 +63,7 @@ class ThreadedWriter(Writer):
         bytes_io=False,
         cpu=False,
         fns=None,
+        suffix=None,
     ):
         # set variables
         self.out_dir = out_dir
@@ -91,6 +92,7 @@ class ThreadedWriter(Writer):
         self.use_guid = use_guid
         self.bytes_io = bytes_io
         self.cpu = cpu
+        self.suffix = suffix
 
         # Resolve file system
         self.fs = fs or get_fs_token_paths(str(out_dir))[0]

--- a/nvtabular/io/writer_factory.py
+++ b/nvtabular/io/writer_factory.py
@@ -29,6 +29,7 @@ def writer_factory(
     num_threads=0,
     cpu=False,
     fns=None,
+    suffix=None,
 ):
     if output_format is None:
         return None
@@ -44,6 +45,7 @@ def writer_factory(
         num_threads=num_threads,
         cpu=cpu,
         fns=fns,
+        suffix=suffix,
     )
 
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -599,5 +599,5 @@ def test_dataset_conversion(tmpdir, cpu, preserve_files):
     assert_eq(ds_check.to_ddf().compute(), df, check_index=False)
 
     # Check that the `suffix=".pq"` argument was successful
-    assert glob.glob(os.path.join(pq_path, "*.part.pq"))
+    assert glob.glob(os.path.join(pq_path, "*.pq"))
     assert not glob.glob(os.path.join(pq_path, "*.parquet"))

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -590,10 +590,14 @@ def test_dataset_conversion(tmpdir, cpu, preserve_files):
     # Adding extra ds -> ds2 step to test `base_dataset` usage.
     pq_path = os.path.join(str(tmpdir), "pq_dataset")
     ds2 = nvt.Dataset(ds.to_ddf(), base_dataset=ds)
-    ds2.to_parquet(pq_path, preserve_files=preserve_files)
+    ds2.to_parquet(pq_path, preserve_files=preserve_files, suffix=".pq")
 
     # Check output.
     # Note that we are converting the inital hex strings to int32.
     ds_check = nvt.Dataset(pq_path, engine="parquet")
     df["C0"] = df["C0"].apply(int, base=16).astype("int32")
     assert_eq(ds_check.to_ddf().compute(), df, check_index=False)
+
+    # Check that the `suffix=".pq"` argument was successful
+    assert glob.glob(os.path.join(pq_path, "*.part.pq"))
+    assert not glob.glob(os.path.join(pq_path, "*.parquet"))


### PR DESCRIPTION
Adds a simple feature allowing the user to override the default `".parquet"` and `".data"` file extensions for parquet and hugectr output, respectively.  The primary modivation was the `Dataset.to_parquet` method - That method currently allows the the user to specify `preserve_files=True`, but there is no way for them to specify if the file extension should be changed (and how).  With this PR, the extension will be replaced with the value of `suffix` (defaulting to ".parquet" for parquet), unless the user has already specified explicit names with the `output_files` argument.

**Note**: This feature simplifies conversion code in #672 a bit.

<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
