### PR TITLE
Fit a single stat operator at a time

### DIFF
--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -132,7 +132,7 @@ class Workflow:
                 try:
                     stat = op.fit(column_group.input_column_names, transformed_ddf)
                     if self.client:
-                        computed = self.client.compute(stat).result()
+                        computed = [r.result() for r in self.client.compute([stat])][0]
                     else:
                         computed = dask.compute(stat, scheduler="synchronous")[0]
                 except Exception:


### PR DESCRIPTION
We're seeing unittest failures, usually along the lines of
``` TypeError: float() argument must be a string or a number, not '_NAType'```

This seems to only occur for me when calculating the stats for both FillMedian
and Categorify in a single dask.compute call. Calculating each op independently
doesn't have this problem and seems to work consistently.
