### PR TITLE
Add ddf column-selection code path to _transform_ddf

### DIFF
--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -293,7 +293,7 @@ def _transform_ddf(ddf, column_groups):
     # Otherwise, Dask will not push the column selection into the
     # IO function.
     if all((c.op is None and not c.parents) for c in column_groups):
-        return ddf[columns]
+        return ddf[list(set(columns))]
 
     # TODO: constructing meta like this loses dtype information on the ddf
     # sets it all to 'float64'. We should propogate dtype information along

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -292,8 +292,7 @@ def _transform_ddf(ddf, column_groups):
     # If so, we should perform column selection at the ddf level.
     # Otherwise, Dask will not push the column selection into the
     # IO function.
-    if all((c.op is None and not c.parents) for c in column_groups):
-        return _ddf_column_selection(ddf, column_groups)
+    return ddf[columns]
 
     # TODO: constructing meta like this loses dtype information on the ddf
     # sets it all to 'float64'. We should propogate dtype information along
@@ -312,22 +311,6 @@ def _get_stat_ops(nodes):
 def _get_unique(cols):
     # Need to preserve order in unique-column list
     return list({x: x for x in cols}.keys())
-
-
-def _ddf_column_selection(ddf, column_groups):
-    """Perform column selection for op/parent-Free column groups"""
-    output = None
-    for column_group in column_groups:
-        unique_flattened_cols = _get_unique(column_group.flattened_columns)
-        if column_group.parents or column_group.op:
-            raise ValueError("Passing a complex column group to _ddf_column_selection")
-        df = ddf[unique_flattened_cols]
-        if output is None:
-            output = df[unique_flattened_cols]
-        else:
-            for col in unique_flattened_cols:
-                output[col] = df[col]
-    return output
 
 
 def _transform_partition(root_df, column_groups):

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -293,7 +293,7 @@ def _transform_ddf(ddf, column_groups):
     # Otherwise, Dask will not push the column selection into the
     # IO function.
     if all((c.op is None and not c.parents) for c in column_groups):
-        return ddf[list(set(columns))]
+        return ddf[_get_unique(columns)]
 
     # TODO: constructing meta like this loses dtype information on the ddf
     # sets it all to 'float64'. We should propogate dtype information along

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -322,10 +322,11 @@ def _ddf_column_selection(ddf, column_groups):
         if column_group.parents or column_group.op:
             raise ValueError("Passing a complex column group to _ddf_column_selection")
         df = ddf[unique_flattened_cols]
-        if not output:
+        if output is None:
             output = df[unique_flattened_cols]
         else:
-            output = _concat_columns([output, df[unique_flattened_cols]])
+            for col in unique_flattened_cols:
+                output[col] = df[col]
     return output
 
 

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -292,7 +292,8 @@ def _transform_ddf(ddf, column_groups):
     # If so, we should perform column selection at the ddf level.
     # Otherwise, Dask will not push the column selection into the
     # IO function.
-    return ddf[columns]
+    if all((c.op is None and not c.parents) for c in column_groups):
+        return ddf[columns]
 
     # TODO: constructing meta like this loses dtype information on the ddf
     # sets it all to 'float64'. We should propogate dtype information along


### PR DESCRIPTION
While trying to find the root cause for the CI failures mentioned in #687, I noticed that NVTabular is not selecting columns in a way that allows Dask to push the selection down to read_parquet at graph-optimization time.  This PR adds a simple code path to perform column selection at the ddf level within `_transform_ddf` in cases where the `column_groups` are all simple column lists (no attached ops or parents).


Optimized read-parquet graph layer BEFORE this change (for a 'x', 'y', 'id' selection):
```
{'read-parquet-f6433cfb39b77001e5a8aae0a9a98bce': ParquetSubgraph<name='read-parquet-f6433cfb39b77001e5a8aae0a9a98bce', n_parts=2, columns=['label', 'x', 'id', 'name-cat', 'name-string', 'y']>}
```

Optimized read-parquet graph layer AFTER this change (for a 'x', 'y', 'id' selection):
```
{'read-parquet-9bb9af4d8bdbd3d554c829c1186dcf5a': ParquetSubgraph<name='read-parquet-9bb9af4d8bdbd3d554c829c1186dcf5a', n_parts=2, columns=['x', 'y', 'id']>}
```

Notice that the column list changes in the `ParquetSubgraph` repr.

<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
