### PR TITLE
Fix test_tf_layers on A100

### DIFF
--- a/tests/unit/test_tf_layers.py
+++ b/tests/unit/test_tf_layers.py
@@ -284,8 +284,8 @@ def test_dot_product_interaction_layer(
             expected_outputs.append((x_i * x_j).sum(axis=1))
     expected_output = np.stack(expected_outputs).T
 
-    rtol = 1e-3
-    atol = 1e-6
+    rtol = 1e-1
+    atol = 1e-2
     match = np.isclose(expected_output, y_hat, rtol=rtol, atol=atol)
     assert match.all()
 


### PR DESCRIPTION
@benfred 

For A100 I am getting the following error
```
============================================================ short test summary info =============================================================
FAILED tests/unit/test_tf_dataloader.py::test_horovod_multigpu - assert 'Loss:' in "b''"
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[True-None-64-4] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[True-None-64-16] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[True-field_all-64-4] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[True-field_all-64-16] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[True-field_each-1-4] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[True-field_each-64-4] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[True-field_each-64-16] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[True-field_interaction-1-16] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[False-None-64-4] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[False-None-64-16] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[False-field_all-64-4] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[False-field_all-64-16] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[False-field_each-64-4] - assert False
FAILED tests/unit/test_tf_layers.py::test_dot_product_interaction_layer[False-field_each-64-16] - assert False
```

I get the test passing by just increasing the error tolerance, but it looks like something is broken.