### PR TITLE
set long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     author="NVIDIA Corporation",
     license="Apache 2.0",
     long_description=open("README.md", encoding="utf8").read(),
+    long_description_content_type="text/markdown",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Our README isn't rendering right at https://pypi.org/project/nvtabular. Fix
by setting long_description_content_type in setup.py
