### PR TITLE
Use parquet metadata to optimize DataFrameIter.__len__

### DIFF
--- a/nvtabular/io/dataset.py
+++ b/nvtabular/io/dataset.py
@@ -366,12 +366,6 @@ class Dataset:
     def partition_lens(self):
         return self.engine._partition_lens
 
-    def __len__(self):
-        try:
-            return sum(self.partition_lens)
-        except AttributeError:
-            return len(self.to_ddf())
-
     def to_cpu(self):
         warnings.warn(
             "Changing an NVTabular Dataset to CPU mode."

--- a/nvtabular/io/parquet.py
+++ b/nvtabular/io/parquet.py
@@ -133,6 +133,7 @@ class ParquetDatasetEngine(DatasetEngine):
         # to collect useful information from the parquet metadata
 
         _pp_nrows = []
+
         def _update_partition_lens(part_count, md, num_row_groups, rg_offset=None):
             # Helper function to calculate the row count for each
             # output partition (and add it to `_pp_nrows`)
@@ -141,12 +142,7 @@ class ParquetDatasetEngine(DatasetEngine):
                 rg_i = _p * self.row_groups_per_part
                 rg_f = min((_p + 1) * self.row_groups_per_part, num_row_groups)
                 _pp_nrows.append(
-                    sum(
-                        [
-                            md.row_group(rg + rg_offset).num_rows
-                            for rg in range(rg_i, rg_f)
-                        ]
-                    )
+                    sum([md.row_group(rg + rg_offset).num_rows for rg in range(rg_i, rg_f)])
                 )
             return
 
@@ -184,7 +180,6 @@ class ParquetDatasetEngine(DatasetEngine):
 
         self._pp_map = _pp_map
         self._pp_nrows = _pp_nrows
-
 
     def to_ddf(self, columns=None, cpu=None):
 

--- a/nvtabular/io/parquet.py
+++ b/nvtabular/io/parquet.py
@@ -67,6 +67,8 @@ class ParquetDatasetEngine(DatasetEngine):
         cpu=False,
     ):
         super().__init__(paths, part_size, cpu=cpu, storage_options=storage_options)
+        self._pp_map = None
+        self._pp_nrows = None
         if row_groups_per_part is None:
             path0 = self._dataset.pieces[0].path
             with self.fs.open(path0, "rb") as f0:
@@ -112,13 +114,13 @@ class ParquetDatasetEngine(DatasetEngine):
 
     @property
     def _file_partition_map(self):
-        if not hasattr(self, "_pp_map"):
+        if self._pp_map is None:
             self._process_parquet_metadata()
         return self._pp_map
 
     @property
     def _partition_lens(self):
-        if not hasattr(self, "_pp_nrows"):
+        if self._pp_nrows is None:
             self._process_parquet_metadata()
         return self._pp_nrows
 

--- a/nvtabular/io/parquet.py
+++ b/nvtabular/io/parquet.py
@@ -138,9 +138,8 @@ class ParquetDatasetEngine(DatasetEngine):
             # Helper function to calculate the row count for each
             # output partition (and add it to `_pp_nrows`)
             rg_offset = rg_offset or 0
-            for _p in range(part_count):
-                rg_i = _p * self.row_groups_per_part
-                rg_f = min((_p + 1) * self.row_groups_per_part, num_row_groups)
+            for rg_i in range(0, part_count, self.row_groups_per_part):
+                rg_f = min(rg_i + self.row_groups_per_part, num_row_groups)
                 _pp_nrows.append(
                     sum([md.row_group(rg + rg_offset).num_rows for rg in range(rg_i, rg_f)])
                 )

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -97,6 +97,7 @@ class Workflow:
             client=self.client,
             cpu=dataset.cpu,
             base_dataset=dataset.base_dataset,
+            base_mapping=dataset.base_mapping,
         )
 
     def fit(self, dataset: Dataset):

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -97,7 +97,6 @@ class Workflow:
             client=self.client,
             cpu=dataset.cpu,
             base_dataset=dataset.base_dataset,
-            base_mapping=dataset.base_mapping,
         )
 
     def fit(self, dataset: Dataset):


### PR DESCRIPTION
Closes #684 

This PR adds the necessary logic to leverage parquet metadata to dramatically improve the performance of taking the length of large datasets.  The primary target is code like the following:

```python
len(nvt.Dataset("/parquet/data", engine="parquet").to_iter())
```

Note that we can also use the parquet metadata to speed up `len` even after a Dataset object has been transformed, but the answer will be wrong if a transformation has dropped or added rows.  If the user can guarentee that this is not a problem, they can do the following when they convert a Dataset to an iterator: `dataset.to_iter(use_file_metadata=True)`.

Note that this PR no longer attempts to support the file-metadata optimization when the iterator is intialized with `shuffle=True`.