### PR TITLE
Fix partition length calculation

### DIFF
--- a/nvtabular/io/parquet.py
+++ b/nvtabular/io/parquet.py
@@ -136,11 +136,11 @@ class ParquetDatasetEngine(DatasetEngine):
 
         _pp_nrows = []
 
-        def _update_partition_lens(part_count, md, num_row_groups, rg_offset=None):
+        def _update_partition_lens(md, num_row_groups, rg_offset=None):
             # Helper function to calculate the row count for each
             # output partition (and add it to `_pp_nrows`)
             rg_offset = rg_offset or 0
-            for rg_i in range(0, part_count, self.row_groups_per_part):
+            for rg_i in range(0, num_row_groups, self.row_groups_per_part):
                 rg_f = min(rg_i + self.row_groups_per_part, num_row_groups)
                 _pp_nrows.append(
                     sum([md.row_group(rg + rg_offset).num_rows for rg in range(rg_i, rg_f)])
@@ -163,7 +163,7 @@ class ParquetDatasetEngine(DatasetEngine):
             for fn, num_row_groups in _path_row_groups.items():
                 part_count = math.ceil(num_row_groups / self.row_groups_per_part)
                 _pp_map[fn] = np.arange(ind, ind + part_count)
-                _update_partition_lens(part_count, dataset.metadata, num_row_groups, rg_offset=rg)
+                _update_partition_lens(dataset.metadata, num_row_groups, rg_offset=rg)
                 ind += part_count
                 rg += num_row_groups
         else:
@@ -176,7 +176,7 @@ class ParquetDatasetEngine(DatasetEngine):
                 part_count = math.ceil(num_row_groups / self.row_groups_per_part)
                 fn = piece.path.split(self.fs.sep)[-1]
                 _pp_map[fn] = np.arange(ind, ind + part_count)
-                _update_partition_lens(part_count, md, num_row_groups)
+                _update_partition_lens(md, num_row_groups)
                 ind += part_count
 
         self._pp_map = _pp_map


### PR DESCRIPTION
We're seeing some failures in the TF movielens notebooks, failing with

```
/nvtabular/nvtabular/io/dataset.py in <genexpr>(.0)
    913             # will not be correct if rows where added or dropped
    914             # after IO (within Ops).
--> 915             return sum(self.partition_lens[i] for i in self.indices)
    916         if len(self.indices) < self._ddf.npartitions:
    917             return len(self._ddf.partitions[self.indices])
IndexError: list index out of range
```

This error seems to be because we have only a single partition_lens available,
but there are two partitions and indices in the dataset.

Fix by fixing the logic that calculates this partition_lens. The row_groups_per_part
was being included twice in the iterating over the partitions (once in calculating the
number of partitions, and also once in the step size).

<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
