### PR TITLE
Fix shuffling in Torch DataLoader

### DIFF
--- a/nvtabular/loader/backend.py
+++ b/nvtabular/loader/backend.py
@@ -120,7 +120,7 @@ class ChunkQueue:
                     chunks.reset_index(drop=True, inplace=True)
                     chunks, spill = self.get_batch_div_chunk(chunks, self.dataloader.batch_size)
                     if self.shuffle:
-                        _shuffle_df(chunks)
+                        chunks = _shuffle_df(chunks)
 
                     if len(chunks) > 0:
                         chunks = self.dataloader.make_tensors(chunks, self.dataloader._use_nnz)

--- a/tests/unit/test_torch_dataloader.py
+++ b/tests/unit/test_torch_dataloader.py
@@ -21,12 +21,15 @@ import time
 
 import cudf
 import numba.cuda
+import numpy as np
+import pandas as pd
 import pytest
 from cudf.tests.utils import assert_eq
 
 import nvtabular as nvt
 import nvtabular.tools.data_gen as datagen
 from nvtabular import ops
+from nvtabular.io.dataset import Dataset
 from tests.conftest import mycols_csv, mycols_pq
 
 # If pytorch isn't installed skip these tests. Note that the
@@ -37,6 +40,25 @@ from nvtabular.framework_utils.torch.models import Model  # noqa isort:skip
 from nvtabular.framework_utils.torch.utils import process_epoch  # noqa isort:skip
 
 GPU_DEVICE_IDS = [d.id for d in numba.cuda.gpus]
+
+
+def test_shuffling():
+    num_rows = 10000
+    batch_size = 10000
+
+    df = pd.DataFrame({"a": np.asarray(range(num_rows)), "b": np.asarray([0] * num_rows)})
+
+    train_dataset = torch_dataloader.TorchAsyncItr(
+        Dataset(df), conts=["a"], labels=["b"], batch_size=batch_size, shuffle=True
+    )
+
+    batch = next(iter(train_dataset))
+
+    first_batch = batch[1].cpu()
+    in_order = torch.arange(0, batch_size)
+
+    assert (first_batch != in_order).any()
+    assert (torch.sort(first_batch).values == in_order).all()
 
 
 @pytest.mark.parametrize("batch_size", [10, 9, 8])
@@ -304,7 +326,7 @@ def test_kill_dl(tmpdir, df, dataset, part_mem_fraction, engine):
     for batch_size in [2 ** i for i in range(9, 25, 1)]:
         print("Checking batch size: ", batch_size)
         num_iter = max(10 * 1000 * 1000 // batch_size, 100)  # load 10e7 samples
-        # import pdb; pdb.set_trace()
+
         data_itr.batch_size = batch_size
         start = time.time()
         i = 0


### PR DESCRIPTION
At some point in the past (after `v0.2.0` and before `v0.3.0`), the assignment in this line was lost, which breaks the shuffling in the `DataLoader` back-end.