### PR TITLE
Fix "Unsupported type_id conversion" in triton inference

### DIFF
--- a/nvtabular/inference/triton/__init__.py
+++ b/nvtabular/inference/triton/__init__.py
@@ -644,3 +644,13 @@ def _convert_dtype(dtype):
     if cudf.utils.dtypes.is_string_dtype(dtype):
         return model_config.TYPE_STRING
     raise ValueError(f"Can't convert dtype {dtype})")
+
+
+def _convert_tensor(t):
+    out = t.as_numpy()
+    if len(out.shape) == 2:
+        out = out[:, 0]
+    # cudf doesn't seem to handle dtypes like |S15 or object that well
+    if cudf.utils.dtypes.is_string_dtype(out.dtype):
+        out = out.astype("str")
+    return out

--- a/nvtabular/inference/triton/model.py
+++ b/nvtabular/inference/triton/model.py
@@ -41,6 +41,7 @@ from triton_python_backend_utils import (
 )
 
 import nvtabular
+from nvtabular.inference.triton import _convert_tensor
 
 
 class TritonPythonModel:
@@ -130,13 +131,3 @@ class TritonPythonModel:
             responses.append(InferenceResponse(output_tensors))
 
         return responses
-
-
-def _convert_tensor(t):
-    out = t.as_numpy()
-    if len(out.shape) == 2:
-        out = out[:, 0]
-    # cudf doesn't seem to handle dtypes like |S15
-    if out.dtype.kind == "S" and out.dtype.str.startswith("|S"):
-        out = out.astype("str")
-    return out

--- a/nvtabular/inference/triton/model_hugectr.py
+++ b/nvtabular/inference/triton/model_hugectr.py
@@ -38,7 +38,7 @@ from triton_python_backend_utils import (
 )
 
 import nvtabular
-from nvtabular.inference.triton import get_column_types
+from nvtabular.inference.triton import _convert_tensor, get_column_types
 
 
 class TritonPythonModel:
@@ -112,16 +112,6 @@ def _convert_cudf2numpy(df, dtype):
         d[:, i] = df[name].values_host
 
     return d.reshape(1, df.shape[0] * df.shape[1]).astype(dtype)
-
-
-def _convert_tensor(t):
-    out = t.as_numpy()
-    if len(out.shape) == 2:
-        out = out[:, 0]
-    # cudf doesn't seem to handle dtypes like |S15
-    if out.dtype.kind == "S" and out.dtype.str.startswith("|S"):
-        out = out.astype("str")
-    return out
 
 
 def get_offsets(path):

--- a/nvtabular/inference/triton/model_pytorch.py
+++ b/nvtabular/inference/triton/model_pytorch.py
@@ -38,7 +38,7 @@ from triton_python_backend_utils import (
 )
 
 import nvtabular
-from nvtabular.inference.triton import get_column_types
+from nvtabular.inference.triton import _convert_tensor, get_column_types
 
 
 class TritonPythonModel:
@@ -87,13 +87,3 @@ def _convert_cudf2numpy(df, dtype):
         d[:, i] = df[name].values_host.astype(dtype)
 
     return d
-
-
-def _convert_tensor(t):
-    out = t.as_numpy()
-    if len(out.shape) == 2:
-        out = out[:, 0]
-    # cudf doesn't seem to handle dtypes like |S15
-    if out.dtype.kind == "S" and out.dtype.str.startswith("|S"):
-        out = out.astype("str")
-    return out

--- a/tests/unit/test_triton_inference.py
+++ b/tests/unit/test_triton_inference.py
@@ -1,4 +1,9 @@
+import contextlib
 import os
+import signal
+import subprocess
+import time
+from distutils.spawn import find_executable
 
 import cudf
 import pytest
@@ -8,6 +13,58 @@ import nvtabular as nvt
 import nvtabular.ops as ops
 
 triton = pytest.importorskip("nvtabular.inference.triton")
+grpcclient = pytest.importorskip("tritonclient.grpc")
+tritonclient = pytest.importorskip("tritonclient")
+
+
+_TRITON_SERVER_PATH = find_executable("tritonserver")
+
+
+@contextlib.contextmanager
+def run_triton_server(modelpath):
+    cmdline = [_TRITON_SERVER_PATH, "--model-repository", modelpath]
+    with subprocess.Popen(cmdline) as process:
+        try:
+            with grpcclient.InferenceServerClient("localhost:8001") as client:
+                # wait until server is ready
+                for _ in range(20):
+                    try:
+                        ready = client.is_server_ready()
+                    except tritonclient.utils.InferenceServerException:
+                        ready = False
+
+                    if ready:
+                        yield client
+                        return
+
+                    time.sleep(1)
+
+                raise RuntimeError("Timed out waiting for tritonserver to become ready")
+        finally:
+            # signal triton to shutdown
+            process.send_signal(signal.SIGINT)
+
+
+@pytest.mark.skipif(_TRITON_SERVER_PATH is None, reason="Requires tritonserver on the path")
+def test_tritonserver_inference_string(tmpdir):
+    df = cudf.DataFrame({"user": ["aaaa", "bbbb", "cccc", "aaaa", "bbbb", "aaaa"]})
+    features = ["user"] >> ops.Categorify()
+    workflow = nvt.Workflow(features)
+
+    # fit the workflow and test on the input
+    dataset = nvt.Dataset(df)
+    workflow.fit(dataset)
+
+    local_df = workflow.transform(dataset).to_ddf().compute(scheduler="synchronous")
+    model_name = "test_inference_string"
+    triton.generate_nvtabular_model(workflow, model_name, tmpdir + "/test_inference_string")
+
+    inputs = triton.convert_df_to_triton_input(["user"], df)
+    with run_triton_server(tmpdir) as client:
+        response = client.infer(model_name, inputs)
+        user_features = response.as_numpy("user")
+        triton_df = cudf.DataFrame({"user": user_features.reshape(user_features.shape[0])})
+        assert_eq(triton_df, local_df)
 
 
 def test_generate_triton_multihot(tmpdir):

--- a/tests/unit/test_triton_inference.py
+++ b/tests/unit/test_triton_inference.py
@@ -27,7 +27,7 @@ def run_triton_server(modelpath):
         try:
             with grpcclient.InferenceServerClient("localhost:8001") as client:
                 # wait until server is ready
-                for _ in range(20):
+                for _ in range(60):
                     try:
                         ready = client.is_server_ready()
                     except tritonclient.utils.InferenceServerException:


### PR DESCRIPTION
We're hitting an error like " Unsupported type_id conversion to cudf " when running any strings
through nvtabular inference with triton. Fix by converting the dtypes as appropiate in
_convert_tensor.

Also add a basic unittest that would have caught this error, launching tritonserver in a
subprocess and communicating through grpc
