### PR TITLE
Add ability to specify triton backend

### DIFF
--- a/nvtabular/inference/triton/__init__.py
+++ b/nvtabular/inference/triton/__init__.py
@@ -257,12 +257,21 @@ def generate_nvtabular_model(
     conts=None,
     max_batch_size=None,
     output_info=None,
+    backend="python",
 ):
     """converts a workflow to a triton mode"""
 
     workflow.save(os.path.join(output_path, str(version), "workflow"))
     config = _generate_nvtabular_config(
-        workflow, name, output_path, output_model, max_batch_size, cats, conts, output_info
+        workflow,
+        name,
+        output_path,
+        output_model,
+        max_batch_size,
+        cats,
+        conts,
+        output_info,
+        backend=backend,
     )
 
     if output_model == "hugectr":
@@ -353,11 +362,11 @@ def _generate_nvtabular_config(
     cats=None,
     conts=None,
     output_info=None,
+    backend="python",
 ):
     """given a workflow generates the trton modelconfig proto object describing the inputs
     and outputs to that workflow"""
-
-    config = model_config.ModelConfig(name=name, backend="python", max_batch_size=max_batch_size)
+    config = model_config.ModelConfig(name=name, backend=backend, max_batch_size=max_batch_size)
 
     if output_model == "hugectr":
         config.instance_group.append(model_config.ModelInstanceGroup(kind=2))


### PR DESCRIPTION
Lets us generate config's for the C++ backend instead of just always using the
default python backend

