### PR TITLE
Expose useful Dask-Dataframe methods in Dataset class

### DIFF
--- a/nvtabular/io/dataset.py
+++ b/nvtabular/io/dataset.py
@@ -156,6 +156,11 @@ class Dataset:
         DatasetEngine object or string identifier of engine. Current
         string options include: ("parquet", "csv", "avro"). This argument
         is ignored if path_or_source is a DataFrame type.
+    npartitions : int
+        Desired number of Dask-collection partitions to produce in
+        the ``to_ddf`` method when ``path_or_source`` corresponds to a
+        DataFrame type.  This argument is ignored for file-based
+        ``path_or_source`` input.
     part_size : str or int
         Desired size (in bytes) of each Dask partition.
         If None, part_mem_fraction will be used to calculate the
@@ -193,6 +198,7 @@ class Dataset:
         self,
         path_or_source,
         engine=None,
+        npartitions=None,
         part_size=None,
         part_mem_fraction=None,
         storage_options=None,
@@ -218,6 +224,7 @@ class Dataset:
                 "This is an experimental feature with extremely limited support!"
             )
 
+        npartitions = npartitions or 1
         if isinstance(path_or_source, (dask.dataframe.DataFrame, cudf.DataFrame, pd.DataFrame)):
             # User is passing in a <dask.dataframe|cudf|pd>.DataFrame
             # Use DataFrameDatasetEngine
@@ -227,11 +234,13 @@ class Dataset:
             if self.cpu:
                 if isinstance(path_or_source, pd.DataFrame):
                     # Convert pandas DataFrame to pandas-backed dask.dataframe.DataFrame
-                    path_or_source = dask.dataframe.from_pandas(path_or_source, npartitions=1)
+                    path_or_source = dask.dataframe.from_pandas(
+                        path_or_source, sort=False, npartitions=npartitions
+                    )
                 elif isinstance(path_or_source, cudf.DataFrame):
                     # Convert cudf DataFrame to pandas-backed dask.dataframe.DataFrame
                     path_or_source = dask.dataframe.from_pandas(
-                        path_or_source.to_pandas(), npartitions=1
+                        path_or_source.to_pandas(), sort=False, npartitions=npartitions
                     )
                 elif isinstance(path_or_source, dask_cudf.DataFrame):
                     # Convert dask_cudf DataFrame to pandas-backed dask.dataframe.DataFrame
@@ -240,11 +249,13 @@ class Dataset:
             else:
                 if isinstance(path_or_source, cudf.DataFrame):
                     # Convert cudf DataFrame to dask_cudf.DataFrame
-                    path_or_source = dask_cudf.from_cudf(path_or_source, npartitions=1)
+                    path_or_source = dask_cudf.from_cudf(
+                        path_or_source, sort=False, npartitions=npartitions
+                    )
                 elif isinstance(path_or_source, pd.DataFrame):
                     # Convert pandas DataFrame to dask_cudf.DataFrame
                     path_or_source = dask_cudf.from_cudf(
-                        cudf.from_pandas(path_or_source), npartitions=1
+                        cudf.from_pandas(path_or_source), sort=False, npartitions=npartitions
                     )
                 elif not isinstance(path_or_source, dask_cudf.DataFrame):
                     # Convert dask.dataframe.DataFrame DataFrame to dask_cudf.DataFrame
@@ -481,6 +492,58 @@ class Dataset:
         # Fall back to dask.dataframe algorithm
         return Dataset(ddf.shuffle(keys, npartitions=npartitions))
 
+    def repartition(self, npartitions=None, partition_size=None):
+        """Repartition the underlying ddf, and return a new Dataset
+
+        Parameters
+        ----------
+        npartitions : int; default None
+            Number of partitions in output ``Dataset``. Only used if
+            ``partition_size`` isn’t specified.
+        partition_size : int or str; default None
+            Max number of bytes of memory for each partition. Use
+            numbers or strings like '5MB'. If specified, ``npartitions``
+            will be ignored.
+        """
+        return Dataset(
+            self.to_ddf()
+            .clear_divisions()
+            .repartition(
+                npartitions=npartitions,
+                partition_size=partition_size,
+            )
+        )
+
+    @classmethod
+    def merge(cls, left, right, **kwargs):
+        """Merge two Dataset objects
+
+        Produces a new Dataset object. See Dask-Dataframe ``merge``
+        documentation for more information. Example usage::
+
+            ds_1 = Dataset("file.parquet")
+            ds_2 = Dataset(cudf.DataFrame(...))
+            ds_merged = Dataset.merge(ds_1, ds_2, on="foo", how="inner")
+
+        Parameters
+        ----------
+        left : Dataset
+            Left-side Dataset object.
+        right : Dataset
+            Right-side Dataset object.
+        **kwargs :
+            Key-word arguments to be passed through to Dask-Dataframe.
+        """
+
+        return cls(
+            left.to_ddf()
+            .clear_divisions()
+            .merge(
+                right.to_ddf().clear_divisions(),
+                **kwargs,
+            )
+        )
+
     def to_iter(self, columns=None, indices=None, shuffle=False, seed=None, use_file_metadata=None):
         """Convert `Dataset` object to a `cudf.DataFrame` iterator.
 
@@ -635,6 +698,15 @@ class Dataset:
 
         # Convert `output_files` argument to a dict mapping
         if output_files:
+
+            # First, repartition ddf if necessary
+            required_npartitions = ddf.npartitions
+            if isinstance(output_files, int):
+                required_npartitions = output_files
+            elif isinstance(output_files, list):
+                required_npartitions = len(output_files)
+            if ddf.npartitions < required_npartitions:
+                ddf = ddf.clear_divisions().repartition(npartitions=required_npartitions)
 
             if isinstance(output_files, int):
                 output_files = [f"part_{i}" + suffix for i in range(output_files)]
@@ -888,6 +960,22 @@ class Dataset:
             return result.compute()
         else:
             return result
+
+    @classmethod
+    def _bind_dd_method(cls, name):
+        """Bind Dask-Dataframe method to the Dataset class"""
+
+        def meth(self, *args, **kwargs):
+            _meth = getattr(self.to_ddf(), name)
+            return _meth(*args, **kwargs)
+
+        meth.__name__ = name
+        setattr(cls, name, meth)
+
+
+# Bind (simple) Dask-Dataframe Methods
+for op in ["compute", "persist", "head", "tail"]:
+    Dataset._bind_dd_method(op)
 
 
 def _set_dtypes(chunk, dtypes):

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -205,11 +205,9 @@ def test_dask_datframe_methods(tmpdir, cpu):
     ds3 = ds3.repartition(npartitions=4)
     assert ds3.npartitions == 4
 
-    # Check head and tail
-    assert_eq(ds3.head(1), ds3.compute().head(1))
-    assert_eq(ds3.tail(1), ds3.compute().tail(1))
-
-    # Check that persist is recognized
+    # Check that head, tail, and persist are recognized
+    ds1.head()
+    ds1.tail()
     ds1.persist()
 
     # Check merge result

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -352,7 +352,7 @@ def test_dataset_partition_shuffle(tmpdir):
 
 @pytest.mark.parametrize("engine", ["csv"])
 @pytest.mark.parametrize("num_io_threads", [0, 2])
-@pytest.mark.parametrize("nfiles", [0, 1, 2])
+@pytest.mark.parametrize("nfiles", [0, 1, 5])  # Use 5 to test repartition in to_parquet
 @pytest.mark.parametrize("shuffle", [nvt.io.Shuffle.PER_WORKER, None])
 @pytest.mark.parametrize("file_map", [True, False])
 def test_multifile_parquet(tmpdir, dataset, df, engine, num_io_threads, nfiles, shuffle, file_map):


### PR DESCRIPTION
This PR has four general goals:

1. Expose common/useful Dask-Dataframe methods in `Dataset`.  This includes `compute`, `persist`, `head`, `tail`, `repartition`, and `merge`.  The idea is to make it easier for users to do Dask-like things without using `to_ddf` (e.g. `datset.head()` instead of `datset.to_ddf().head()`, and `datset.repartition(npartitions=8)` instead of `Dataset(datset.to_ddf().repartition(npartitions=8))` (note that `repartition` also supports the `partition_size` argument, where something like "1GB" can be used to specify the desired partition size).
2. Fix problematic `output_files` behavior in `to_parquet` when the user asks for a larger number of output files than the total number of partitions.  This PR adds an implicit `repartition` step to make sure NVTabular will actually produce the correct number of output files.
3. Make it possible for the user to merge two `Dataset` objects (using `Datset.merge`)
4. Add an optional `npartitions` argument to the `Dataset` initializer so that an input pandas/cudf DataFrame can be partitioned.

<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
