### PR TITLE
Adding map function to KerasSequenceLoader

### DIFF
--- a/nvtabular/loader/tensorflow.py
+++ b/nvtabular/loader/tensorflow.py
@@ -249,6 +249,7 @@ class KerasSequenceLoader(tf.keras.utils.Sequence, DataLoader):
             sparse_max=sparse_max,
             sparse_as_dense=sparse_as_dense,
         )
+        self._map_fns = []
 
     def __len__(self):
         """
@@ -266,6 +267,16 @@ class KerasSequenceLoader(tf.keras.utils.Sequence, DataLoader):
         passed idx in any way
         """
         return DataLoader.__next__(self)
+
+    def map(self, fn):
+        """
+        Applying a function to each batch.
+
+        This can for instance be used to add `sample_weight` to the model.
+        """
+        self._map_fns.append(fn)
+
+        return self
 
     @contextlib.contextmanager
     def _get_device_ctx(self, dev):
@@ -379,6 +390,14 @@ class KerasSequenceLoader(tf.keras.utils.Sequence, DataLoader):
         if self.sparse_as_dense:
             tensor = tf.sparse.to_dense(tensor)
         return tensor
+
+    def _handle_tensors(self, cats, conts, labels):
+        to_return = super()._handle_tensors(cats, conts, labels)
+
+        for map_fn in self._map_fns:
+            to_return = map_fn(*to_return)
+
+        return to_return
 
 
 class KerasSequenceValidater(tf.keras.callbacks.Callback):


### PR DESCRIPTION
This makes the API of the TF dataloader a bit more familiar for the average TF-user, since `tf.data.Dataset` contains a similar function ([source](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#map)).

This new function can also be used to pass `sample_weight` to a keras-model, like requested in #667. Example:

```python
df = cudf.DataFrame(
    {
        "cat1": [1] * 100,
        "cat2": [2] * 100,
        "cat3": [3] * 100,
        "label": [0] * 100,
        "sample_weight": [1.0] * 100,
        "cont2": [2.0] * 100,
        "cont1": [1.0] * 100,
    }
)
path = os.path.join("tmp", "dataset.parquet")
df.to_parquet(path)
cat_names = ["cat3", "cat2", "cat1"]
cont_names = ["sample_weight", "cont2", "cont1"]
label_name = ["label"]

def add_sample_weight(features, labels, sample_weight_col_name="sample_weight"):
    sample_weight = tf.cast(features.pop(sample_weight_col_name) > 0, tf.float32)

    return features, labels, sample_weight

data_itr = KerasSequenceLoader(
    [path],
    cat_names=cat_names,
    cont_names=cont_names,
    batch_size=10,
    label_names=label_name,
    shuffle=False,
).map(add_sample_weight)

for X, y, sample_weight in data_itr:
    assert list(sample_weight.numpy()) == [1.0] * 10
```