### PR TITLE
Provide better graph labels for LambaOp

### DIFF
--- a/nvtabular/column_group.py
+++ b/nvtabular/column_group.py
@@ -205,7 +205,7 @@ class ColumnGroup:
     @property
     def label(self):
         if self.op:
-            return str(self.op.__class__.__name__)
+            return self.op.label
         elif self.kind:
             return self.kind
         elif not self.parents:

--- a/nvtabular/ops/operator.py
+++ b/nvtabular/ops/operator.py
@@ -79,3 +79,7 @@ class Operator:
         import nvtabular
 
         return nvtabular.ColumnGroup(other) >> self
+
+    @property
+    def label(self) -> str:
+        return self.__class__.__name__


### PR DESCRIPTION
The workflow graphs all had 'LambdaOp' before, which was pretty confusing if you
had multiple lambdas in the workflow. This change adds a 'label' to the operator
api which is used to label nodes in the graph.

LambdaOp will now allow users to specify their own label, or alternatively will
try to figure out a decent representation from the function itself using the
inspect module.

Closes #860 

