### PR TITLE
CPU Support for Data_stats / Dropna / DifferenceLag / Hash_bucket / Hashed_cross

### DIFF
--- a/nvtabular/dispatch.py
+++ b/nvtabular/dispatch.py
@@ -63,11 +63,13 @@ def _is_series_object(x):
     # Series object
     return isinstance(x, (cudf.Series, pd.Series))
 
+
 def _create_frame(x, df):
     if isinstance(df, cudf.DataFrame):
         return cudf.DataFrame(x)
     else:
         return pd.DataFrame(x)
+
 
 def _hex_to_int(s, dtype=None):
     def _pd_convert_hex(x):

--- a/nvtabular/dispatch.py
+++ b/nvtabular/dispatch.py
@@ -63,6 +63,11 @@ def _is_series_object(x):
     # Series object
     return isinstance(x, (cudf.Series, pd.Series))
 
+def _create_frame(x, df):
+    if isinstance(df, cudf.DataFrame):
+        return cudf.DataFrame(x)
+    else:
+        return pd.DataFrame(x)
 
 def _hex_to_int(s, dtype=None):
     def _pd_convert_hex(x):

--- a/nvtabular/dispatch.py
+++ b/nvtabular/dispatch.py
@@ -64,13 +64,6 @@ def _is_series_object(x):
     return isinstance(x, (cudf.Series, pd.Series))
 
 
-def _create_frame(x, df):
-    if isinstance(df, cudf.DataFrame):
-        return cudf.DataFrame(x)
-    else:
-        return pd.DataFrame(x)
-
-
 def _hex_to_int(s, dtype=None):
     def _pd_convert_hex(x):
         if pd.isnull(x):

--- a/nvtabular/ops/data_stats.py
+++ b/nvtabular/ops/data_stats.py
@@ -22,6 +22,8 @@ from .moments import _custom_moments
 from .operator import ColumnNames, Operator
 from .stat_operator import StatOperator
 
+from nvtabular.dispatch import DataFrameType
+import dask.dataframe as dd
 
 class DataStats(StatOperator):
     def __init__(self):
@@ -31,11 +33,11 @@ class DataStats(StatOperator):
         self.col_dtypes = []
         self.output = {}
 
-    def transform(self, columns: ColumnNames, gdf: cudf.DataFrame) -> cudf.DataFrame:
-        return gdf
+    def transform(self, columns: ColumnNames, df: DataFrameType) -> DataFrameType:
+        return df
 
     @annotate("DataStats_fit", color="green", domain="nvt_python")
-    def fit(self, columns: ColumnNames, ddf: dask_cudf.DataFrame):
+    def fit(self, columns: ColumnNames, ddf: dd.DataFrame):
         dask_stats = {}
 
         ddf_dtypes = ddf.head(1)

--- a/nvtabular/ops/data_stats.py
+++ b/nvtabular/ops/data_stats.py
@@ -13,17 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import cudf
-import dask_cudf
+import dask.dataframe as dd
 import numpy as np
 from nvtx import annotate
+
+from nvtabular.dispatch import DataFrameType
 
 from .moments import _custom_moments
 from .operator import ColumnNames, Operator
 from .stat_operator import StatOperator
 
-from nvtabular.dispatch import DataFrameType
-import dask.dataframe as dd
 
 class DataStats(StatOperator):
     def __init__(self):

--- a/nvtabular/ops/difference_lag.py
+++ b/nvtabular/ops/difference_lag.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import cudf
 from nvtx import annotate
+
+from nvtabular.dispatch import DataFrameType, _create_frame, _is_dataframe_object
 
 from .operator import ColumnNames, Operator
 
-from nvtabular.dispatch import DataFrameType, _create_frame, _is_dataframe_object
 
 class DifferenceLag(Operator):
     """Calculates the difference between two consecutive rows of the dataset. For instance, this

--- a/nvtabular/ops/difference_lag.py
+++ b/nvtabular/ops/difference_lag.py
@@ -15,7 +15,7 @@
 #
 from nvtx import annotate
 
-from nvtabular.dispatch import DataFrameType, _create_frame, _is_dataframe_object
+from nvtabular.dispatch import DataFrameType, _is_dataframe_object
 
 from .operator import ColumnNames, Operator
 
@@ -71,7 +71,7 @@ class DifferenceLag(Operator):
 
             for col in columns:
                 output[self._column_name(col, shift)] = (df[col] - df[col].shift(shift)) * mask
-        return _create_frame(output, df)
+        return type(df)(output)
 
     transform.__doc__ = Operator.transform.__doc__
 

--- a/nvtabular/ops/dropna.py
+++ b/nvtabular/ops/dropna.py
@@ -15,8 +15,9 @@
 #
 from nvtx import annotate
 
-from .operator import ColumnNames, DataFrameType, Operator
+from .operator import ColumnNames, Operator
 
+from nvtabular.dispatch import DataFrameType
 
 class Dropna(Operator):
     """
@@ -34,7 +35,7 @@ class Dropna(Operator):
     """
 
     @annotate("Dropna_op", color="darkgreen", domain="nvt_python")
-    def transform(self, columns: ColumnNames, gdf: DataFrameType) -> DataFrameType:
-        new_gdf = gdf.dropna(subset=columns or None)
-        new_gdf.reset_index(drop=True, inplace=True)
-        return new_gdf
+    def transform(self, columns: ColumnNames, df: DataFrameType) -> DataFrameType:
+        new_df = df.dropna(subset=columns or None)
+        new_df.reset_index(drop=True, inplace=True)
+        return new_df

--- a/nvtabular/ops/dropna.py
+++ b/nvtabular/ops/dropna.py
@@ -15,9 +15,10 @@
 #
 from nvtx import annotate
 
+from nvtabular.dispatch import DataFrameType
+
 from .operator import ColumnNames, Operator
 
-from nvtabular.dispatch import DataFrameType
 
 class Dropna(Operator):
     """

--- a/nvtabular/ops/hash_bucket.py
+++ b/nvtabular/ops/hash_bucket.py
@@ -15,11 +15,10 @@
 #
 from typing import Dict, Union
 
-import cudf
 from cudf.utils.dtypes import is_list_dtype
 from nvtx import annotate
 
-from ..dispatch import _encode_list_column, DataFrameType, _hash_series
+from ..dispatch import DataFrameType, _encode_list_column, _hash_series
 from .categorify import _emb_sz_rule, _get_embedding_order
 from .operator import ColumnNames, Operator
 

--- a/nvtabular/ops/hash_bucket.py
+++ b/nvtabular/ops/hash_bucket.py
@@ -19,7 +19,7 @@ import cudf
 from cudf.utils.dtypes import is_list_dtype
 from nvtx import annotate
 
-from ..dispatch import _encode_list_column
+from ..dispatch import _encode_list_column, DataFrameType, _hash_series
 from .categorify import _emb_sz_rule, _get_embedding_order
 from .operator import ColumnNames, Operator
 
@@ -78,18 +78,19 @@ class HashBucket(Operator):
         super(HashBucket, self).__init__()
 
     @annotate("HashBucket_op", color="darkgreen", domain="nvt_python")
-    def transform(self, columns: ColumnNames, gdf: cudf.DataFrame) -> cudf.DataFrame:
+    def transform(self, columns: ColumnNames, df: DataFrameType) -> DataFrameType:
         if isinstance(self.num_buckets, int):
             num_buckets = {name: self.num_buckets for name in columns}
         else:
             num_buckets = self.num_buckets
 
         for col, nb in num_buckets.items():
-            if is_list_dtype(gdf[col].dtype):
-                gdf[col] = _encode_list_column(gdf[col], gdf[col].list.leaves.hash_values() % nb)
+            if is_list_dtype(df[col].dtype):
+                df[col] = _encode_list_column(df[col], _hash_series(df[col]) % nb)
             else:
-                gdf[col] = gdf[col].hash_values() % nb
-        return gdf
+                df[col] = _hash_series(df[col]) % nb
+
+        return df
 
     transform.__doc__ = Operator.transform.__doc__
 

--- a/nvtabular/ops/hashed_cross.py
+++ b/nvtabular/ops/hashed_cross.py
@@ -17,7 +17,7 @@ from typing import Dict, Union
 
 from nvtx import annotate
 
-from nvtabular.dispatch import DataFrameType, _create_frame, _hash_series
+from nvtabular.dispatch import DataFrameType, _hash_series
 
 from .operator import ColumnNames, Operator
 
@@ -55,7 +55,7 @@ class HashedCross(Operator):
 
     @annotate("HashedCross_op", color="darkgreen", domain="nvt_python")
     def transform(self, columns: ColumnNames, df: DataFrameType) -> DataFrameType:
-        new_df = _create_frame({}, df)
+        new_df = type(df)({})
         for cross in _nest_columns(columns):
             val = 0
             for column in cross:

--- a/nvtabular/ops/hashed_cross.py
+++ b/nvtabular/ops/hashed_cross.py
@@ -55,7 +55,7 @@ class HashedCross(Operator):
 
     @annotate("HashedCross_op", color="darkgreen", domain="nvt_python")
     def transform(self, columns: ColumnNames, df: DataFrameType) -> DataFrameType:
-        new_df = type(df)({})
+        new_df = type(df)()
         for cross in _nest_columns(columns):
             val = 0
             for column in cross:

--- a/nvtabular/ops/hashed_cross.py
+++ b/nvtabular/ops/hashed_cross.py
@@ -15,11 +15,12 @@
 
 from typing import Dict, Union
 
-import cudf
 from nvtx import annotate
 
+from nvtabular.dispatch import DataFrameType, _create_frame, _hash_series
+
 from .operator import ColumnNames, Operator
-from nvtabular.dispatch import DataFrameType, _hash_series, _create_frame
+
 
 class HashedCross(Operator):
     """

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -201,7 +201,6 @@ def test_hash_bucket(tmpdir, df, dataset, gpu_memory_frac, engine, op_columns, c
     assert np.all(new_df[cat_names].values >= 0)
     assert np.all(new_df[cat_names].values <= 9)
     checksum = new_df[cat_names].sum().values
-    
 
     new_df = processor.transform(dataset).to_ddf().compute()
     np.all(new_df[cat_names].sum().values == checksum)
@@ -262,10 +261,10 @@ def test_dropna(tmpdir, df, dataset, engine, cpu):
     dropna_features = columns >> ops.Dropna()
     if cpu:
         dataset.to_cpu()
-    
+
     processor = nvt.Workflow(dropna_features)
     processor.fit(dataset)
-    
+
     new_df = processor.transform(dataset).to_ddf().compute()
     assert new_df.columns.all() == df.columns.all()
     assert new_df.isnull().all().sum() < 1, "null values exist"
@@ -913,8 +912,8 @@ def test_difference_lag(cpu):
         assert lib.isna(new_df["timestamp_difference_lag_1"][0])
         assert lib.isna(new_df["timestamp_difference_lag_1"][3])
     else:
-         assert new_df["timestamp_difference_lag_1"][0] is (lib.NA if hasattr(lib, "NA") else None)
-         assert new_df["timestamp_difference_lag_1"][3] is (lib.NA if hasattr(lib, "NA") else None)
+        assert new_df["timestamp_difference_lag_1"][0] is (lib.NA if hasattr(lib, "NA") else None)
+        assert new_df["timestamp_difference_lag_1"][3] is (lib.NA if hasattr(lib, "NA") else None)
 
     assert new_df["timestamp_difference_lag_-1"][0] == -5
     assert new_df["timestamp_difference_lag_-1"][1] == -95
@@ -925,6 +924,7 @@ def test_difference_lag(cpu):
     else:
         assert new_df["timestamp_difference_lag_-1"][2] is (lib.NA if hasattr(lib, "NA") else None)
         assert new_df["timestamp_difference_lag_-1"][5] is (lib.NA if hasattr(lib, "NA") else None)
+
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])
 @pytest.mark.parametrize("engine", ["parquet", "csv", "csv-no-header"])

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -182,9 +182,11 @@ def test_log(tmpdir, df, dataset, gpu_memory_frac, engine, op_columns):
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])
 @pytest.mark.parametrize("engine", ["parquet", "csv", "csv-no-header"])
 @pytest.mark.parametrize("op_columns", [["name-string"], None])
-def test_hash_bucket(tmpdir, df, dataset, gpu_memory_frac, engine, op_columns):
+@pytest.mark.parametrize("cpu", [True, False])
+def test_hash_bucket(tmpdir, df, dataset, gpu_memory_frac, engine, op_columns, cpu):
     cat_names = ["name-string"]
-
+    if cpu:
+        dataset.to_cpu()
     if op_columns is None:
         num_buckets = 10
     else:
@@ -193,14 +195,16 @@ def test_hash_bucket(tmpdir, df, dataset, gpu_memory_frac, engine, op_columns):
     hash_features = cat_names >> ops.HashBucket(num_buckets)
     processor = nvt.Workflow(hash_features)
     processor.fit(dataset)
-    new_gdf = processor.transform(dataset).to_ddf().compute()
+    new_df = processor.transform(dataset).to_ddf().compute()
 
     # check sums for determinancy
-    assert np.all(new_gdf[cat_names].values >= 0)
-    assert np.all(new_gdf[cat_names].values <= 9)
-    checksum = new_gdf[cat_names].sum().values
-    new_gdf = processor.transform(dataset).to_ddf().compute()
-    np.all(new_gdf[cat_names].sum().values == checksum)
+    assert np.all(new_df[cat_names].values >= 0)
+    assert np.all(new_df[cat_names].values <= 9)
+    checksum = new_df[cat_names].sum().values
+    
+
+    new_df = processor.transform(dataset).to_ddf().compute()
+    np.all(new_df[cat_names].sum().values == checksum)
 
 
 def test_hash_bucket_lists(tmpdir):
@@ -924,24 +928,25 @@ def test_difference_lag(cpu):
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])
 @pytest.mark.parametrize("engine", ["parquet", "csv", "csv-no-header"])
-def test_hashed_cross(tmpdir, df, dataset, gpu_memory_frac, engine):
+@pytest.mark.parametrize("cpu", [True, False])
+def test_hashed_cross(tmpdir, df, dataset, gpu_memory_frac, engine, cpu):
     # TODO: add tests for > 2 features, multiple crosses, etc.
     cat_names = [["name-string", "id"]]
     num_buckets = 10
 
     hashed_cross = cat_names >> ops.HashedCross(num_buckets)
-    dataset = nvt.Dataset(df)
+    dataset = nvt.Dataset(df, cpu=cpu)
     processor = nvtabular.Workflow(hashed_cross)
     processor.fit(dataset)
-    new_gdf = processor.transform(dataset).to_ddf().compute()
+    new_df = processor.transform(dataset).to_ddf().compute()
 
     # check sums for determinancy
     new_column_name = "_X_".join(cat_names[0])
-    assert np.all(new_gdf[new_column_name].values >= 0)
-    assert np.all(new_gdf[new_column_name].values <= 9)
-    checksum = new_gdf[new_column_name].sum()
-    new_gdf = processor.transform(dataset).to_ddf().compute()
-    assert new_gdf[new_column_name].sum() == checksum
+    assert np.all(new_df[new_column_name].values >= 0)
+    assert np.all(new_df[new_column_name].values <= 9)
+    checksum = new_df[new_column_name].sum()
+    new_df = processor.transform(dataset).to_ddf().compute()
+    assert new_df[new_column_name].sum() == checksum
 
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -959,14 +959,15 @@ def test_bucketized(tmpdir, df, dataset, gpu_memory_frac, engine, cpu):
 
 
 @pytest.mark.parametrize("engine", ["parquet"])
-def test_data_stats(tmpdir, df, datasets, engine):
+@pytest.mark.parametrize("cpu", [True, False])
+def test_data_stats(tmpdir, df, datasets, engine, cpu):
     # cat_names = ["name-cat", "name-string"] if engine == "parquet" else ["name-string"]
     cat_names = ["name-cat", "name-string"] if engine == "parquet" else ["name-string"]
     cont_names = ["x", "y"]
     label_name = ["label"]
     all_cols = cat_names + cont_names + label_name
 
-    dataset = nvtabular.Dataset(df, engine=engine)
+    dataset = nvtabular.Dataset(df, engine=engine, cpu=cpu)
 
     data_stats = ops.DataStats()
 


### PR DESCRIPTION
Related to #534

Adds support for cpu-backed data in `data_stats` (and test coverage).
Adds support for cpu-backed data in `dropna` (and test coverage).
Adds support for cpu-backed data in `drifference_lag` (and test coverage).
Adds support for cpu-backed data in `Hash_bucket` (and test coverage).
Adds support for cpu-backed data in `Hash_crossed` (and test coverage).
