### PR TITLE
Fix multihots for when not passed a dtype to Categorify

### DIFF
--- a/nvtabular/dispatch.py
+++ b/nvtabular/dispatch.py
@@ -249,8 +249,10 @@ def _encode_list_column(original, encoded, dtype=None):
         return pd.Series(new_data)
     else:
         # CuDF version
+        encoded = as_column(encoded)
+        if dtype:
+            encoded = encoded.astype(dtype, copy=False)
         list_dtype = cudf.core.dtypes.ListDtype(encoded.dtype if dtype is None else dtype)
-        encoded = as_column(encoded).astype(dtype, copy=False)
         return build_column(
             None,
             dtype=list_dtype,

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -437,7 +437,7 @@ def test_lambdaop_misalign(cpu):
 
 @pytest.mark.parametrize("freq_threshold", [0, 1, 2])
 @pytest.mark.parametrize("cpu", [False, True])
-@pytest.mark.parametrize("dtype", [np.int32, np.int64])
+@pytest.mark.parametrize("dtype", [None, np.int32, np.int64])
 def test_categorify_lists(tmpdir, freq_threshold, cpu, dtype):
     df = cudf.DataFrame(
         {
@@ -458,10 +458,10 @@ def test_categorify_lists(tmpdir, freq_threshold, cpu, dtype):
 
     # Columns are encoded independently
     if cpu:
-        assert df_out["Authors"][0].dtype == np.dtype(dtype)
+        assert df_out["Authors"][0].dtype == np.dtype(dtype) if dtype else np.dtype("int64")
         compare = [list(row) for row in df_out["Authors"].tolist()]
     else:
-        assert df_out["Authors"].dtype == cudf.core.dtypes.ListDtype(dtype)
+        assert df_out["Authors"].dtype == cudf.core.dtypes.ListDtype(dtype if dtype else "int64")
         compare = df_out["Authors"].to_arrow().to_pylist()
 
     if freq_threshold < 2:


### PR DESCRIPTION
We are seeing issues with Categorify when not passed a dtype with multihot
columns. For instance the movielens triton TF example fails with

 ```
 E0628 19:45:54.418425 1 model_repository_manager.cc:1430] Invalid argument: in ensemble movielens, ensemble tensor genres__values_nvt: inconsistent data type: TYPE_FP64 is inferred from model movielens_nvt while TYPE_INT64 is inferred from model movielens_tf
 ```

The problem seems to be that calling astype with a None value causes cudf to
change the dtype to int64. Fix.
