### PR TITLE
Add 'supports' and 'inference_initialize' for operators.

### DIFF
--- a/nvtabular/inference/triton/model.py
+++ b/nvtabular/inference/triton/model.py
@@ -48,6 +48,19 @@ from nvtabular.inference.triton import _convert_tensor, get_column_types
 class TritonPythonModel:
     """Generic TritonPythonModel for nvtabular workflows"""
 
+    def _initialize_ops(self, column_group, initialized):
+        if column_group.op:
+            inference_op = column_group.op.inference_initialize(
+                column_group.columns, self.model_config
+            )
+            if inference_op:
+                column_group.op = inference_op
+
+        for parent in column_group.parents:
+            if parent not in initialized:
+                initialized.add(parent)
+                self._initialize_ops(parent, initialized)
+
     def initialize(self, args):
         workflow_path = os.path.join(
             args["model_repository"], str(args["model_version"]), "workflow"
@@ -55,6 +68,10 @@ class TritonPythonModel:
         self.workflow = nvtabular.Workflow.load(workflow_path)
         self.model_config = json.loads(args["model_config"])
         self.output_model = self.model_config["parameters"]["output_model"]["string_value"]
+
+        # recurse over all column groups, initializing operators for inference pipeline
+        initialized_column_groups = set()
+        self._initialize_ops(self.workflow.column_group, initialized_column_groups)
 
         self.input_dtypes = {
             col: dtype

--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -41,6 +41,7 @@ from nvtabular.dispatch import (
     _from_host,
     _hash_series,
     _is_list_dtype,
+    _make_df,
     _parquet_writer_dispatch,
     _read_parquet_dispatch,
     _series_has_nulls,
@@ -420,6 +421,14 @@ class Categorify(StatOperator):
         return _get_embeddings_dask(
             self.categories, columns, self.num_buckets, self.freq_threshold, self.max_size
         )
+
+    def inference_initialize(self, columns: ColumnNames, model_config: dict) -> Optional[Operator]:
+        # on the first transform call we load up categories from disk, which can
+        # take multiple seconds. preload this data by running an empty dataframe through
+        df = _make_df()
+        for column in columns:
+            df[column] = []
+        self.transform(columns, df)
 
     transform.__doc__ = Operator.transform.__doc__
     fit.__doc__ = StatOperator.fit.__doc__

--- a/nvtabular/ops/normalize.py
+++ b/nvtabular/ops/normalize.py
@@ -136,8 +136,8 @@ class NormalizeMinMax(StatOperator):
     @property
     def supports(self):
         return (
-            Supports.CPU_ARRAY
-            | Supports.GPU_ARRAY
+            Supports.CPU_DICT_ARRAY
+            | Supports.GPU_DICT_ARRAY
             | Supports.CPU_DATAFRAME
             | Supports.GPU_DATAFRAME
         )

--- a/nvtabular/ops/normalize.py
+++ b/nvtabular/ops/normalize.py
@@ -19,7 +19,7 @@ from nvtx import annotate
 
 from ..dispatch import DataFrameType
 from .moments import _custom_moments
-from .operator import ColumnNames, Operator
+from .operator import ColumnNames, Operator, Supports
 from .stat_operator import StatOperator
 
 
@@ -62,6 +62,15 @@ class Normalize(StatOperator):
                 new_df[name] = (df[name] - self.means[name]) / (self.stds[name])
                 new_df[name] = new_df[name].astype("float32")
         return new_df
+
+    @property
+    def supports(self):
+        return (
+            Supports.CPU_ARRAY
+            | Supports.GPU_ARRAY
+            | Supports.CPU_DATAFRAME
+            | Supports.GPU_DATAFRAME
+        )
 
     def clear(self):
         self.means = {}
@@ -123,6 +132,15 @@ class NormalizeMinMax(StatOperator):
     def clear(self):
         self.mins = {}
         self.maxs = {}
+
+    @property
+    def supports(self):
+        return (
+            Supports.CPU_ARRAY
+            | Supports.GPU_ARRAY
+            | Supports.CPU_DATAFRAME
+            | Supports.GPU_DATAFRAME
+        )
 
     transform.__doc__ = Operator.transform.__doc__
     fit.__doc__ = StatOperator.fit.__doc__

--- a/nvtabular/ops/normalize.py
+++ b/nvtabular/ops/normalize.py
@@ -66,8 +66,8 @@ class Normalize(StatOperator):
     @property
     def supports(self):
         return (
-            Supports.CPU_ARRAY
-            | Supports.GPU_ARRAY
+            Supports.CPU_DICT_ARRAY
+            | Supports.GPU_DICT_ARRAY
             | Supports.CPU_DATAFRAME
             | Supports.GPU_DATAFRAME
         )

--- a/nvtabular/ops/operator.py
+++ b/nvtabular/ops/operator.py
@@ -28,16 +28,16 @@ ColumnNames = List[Union[str, List[str]]]
 
 
 class Supports(Flag):
-    """ Indicates what type of data representation this operator supports. """
+    """ Indicates what type of data representation this operator supports for transformations """
 
     # cudf dataframe
     CPU_DATAFRAME = auto()
     # pandas dataframe
     GPU_DATAFRAME = auto()
     # dict of column name to numpy array
-    CPU_ARRAY = auto()
+    CPU_DICT_ARRAY = auto()
     # dict of column name to cupy array
-    GPU_ARRAY = auto()
+    GPU_DICT_ARRAY = auto()
 
 
 class Operator:
@@ -105,5 +105,5 @@ class Operator:
 
     def inference_initialize(self, columns: ColumnNames, model_config: dict) -> Optional[Operator]:
         """Configures this operator for use in inference. May return a different operator to use
-        instead of the one configured during training"""
+        instead of the one configured for use during training"""
         return None

--- a/nvtabular/ops/operator.py
+++ b/nvtabular/ops/operator.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+from enum import Flag, auto
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from nvtabular.dispatch import DataFrameType
@@ -24,6 +25,19 @@ if TYPE_CHECKING:
     from nvtabular import ColumnGroup
 
 ColumnNames = List[Union[str, List[str]]]
+
+
+class Supports(Flag):
+    """ Indicates what type of data representation this operator supports. """
+
+    # cudf dataframe
+    CPU_DATAFRAME = auto()
+    # pandas dataframe
+    GPU_DATAFRAME = auto()
+    # dict of column name to numpy array
+    CPU_ARRAY = auto()
+    # dict of column name to cupy array
+    GPU_ARRAY = auto()
 
 
 class Operator:
@@ -83,3 +97,13 @@ class Operator:
     @property
     def label(self) -> str:
         return self.__class__.__name__
+
+    @property
+    def supports(self) -> Supports:
+        """ Returns what kind of data representation this operator supports """
+        return Supports.CPU_DATAFRAME | Supports.GPU_DATAFRAME
+
+    def inference_initialize(self, columns: ColumnNames, model_config: dict) -> Optional[Operator]:
+        """Configures this operator for use in inference. May return a different operator to use
+        instead of the one configured during training"""
+        return None

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -293,6 +293,14 @@ def test_normalize(tmpdir, df, dataset, gpu_memory_frac, engine, op_columns):
         ]
         assert np.all((df[col] - new_gdf[col]).abs().values <= 1e-2)
 
+    # our normalize op also works on dicts of cupy/numpy tensors. make sure this works like we'd
+    # expect
+    df = dataset.compute()
+    cupy_inputs = {col: df[col].values for col in op_columns}
+    cupy_outputs = cont_features.op.transform(op_columns, cupy_inputs)
+    for col in op_columns:
+        assert np.allclose(cupy_outputs[col], new_gdf[col].values)
+
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.1])
 @pytest.mark.parametrize("engine", ["parquet"])


### PR DESCRIPTION
This is the first in a series of PR's for providing optimized inference.

This adds both a 'supports' flag for operators and a 'inference_initialize' method.

The supports flag shows what dataformats the operator can accept during transforms.
We've found for inference that a dictionary of column names to numpy/cupy arrays
can be orders of magnitude faster at inference time. As an example, the normalize operator
works unchanged on these dictionaries, and times for me go from 8ms to around 140us on the
Rossmann dataset using dictionaries of numpy arrays instead of cudf or pandas dataframes.

The inference_initialize change provides a mechanism for operators to provide an optimized
version for inference, as well as to preload any necessary data. This is currently only
serving to preload categories in the categorify op - but will be used to provide optimize
versions of operators in a future PR.
