### PR TITLE
assert_eq import fix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,16 @@ from numba import cuda
 
 import nvtabular
 
+try:
+    import cudf.testing._utils
+
+    assert_eq = cudf.testing._utils.assert_eq
+except ImportError:
+    import cudf.tests.utils
+
+    assert_eq = cudf.tests.utils.assert_eq
+
+
 allcols_csv = ["timestamp", "id", "label", "name-string", "x", "y", "z"]
 mycols_csv = ["name-string", "id", "label", "x", "y"]
 mycols_pq = ["name-cat", "name-string", "id", "label", "x", "y"]

--- a/tests/unit/test_column_group.py
+++ b/tests/unit/test_column_group.py
@@ -1,9 +1,9 @@
 import cudf
 import pytest
-from cudf.tests.utils import assert_eq
 
 from nvtabular import ColumnGroup, Dataset, Workflow
 from nvtabular.ops import Categorify, Rename
+from tests.conftest import assert_eq
 
 
 def test_column_group_select():

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -24,14 +24,13 @@ import dask_cudf
 import numpy as np
 import pandas as pd
 import pytest
-from cudf.tests.utils import assert_eq
 from dask.dataframe import assert_eq as assert_eq_dd
 from pandas.api.types import is_integer_dtype
 
 import nvtabular as nvt
 import nvtabular.io
 from nvtabular import ColumnGroup, ops
-from tests.conftest import mycols_csv, mycols_pq
+from tests.conftest import assert_eq, mycols_csv, mycols_pq
 
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -19,13 +19,12 @@ from io import BytesIO
 
 import cudf
 import pytest
-from cudf.tests.utils import assert_eq
 from dask.dataframe.io.parquet.core import create_metadata_file
 from dask_cudf.io.tests import test_s3
 
 import nvtabular as nvt
 from nvtabular import ops
-from tests.conftest import mycols_csv, mycols_pq
+from tests.conftest import assert_eq, mycols_csv, mycols_pq
 
 # Import fixtures and context managers from dask_cudf
 s3_base = test_s3.s3_base

--- a/tests/unit/test_torch_dataloader.py
+++ b/tests/unit/test_torch_dataloader.py
@@ -23,13 +23,12 @@ import cudf
 import numpy as np
 import pandas as pd
 import pytest
-from cudf.tests.utils import assert_eq
 
 import nvtabular as nvt
 import nvtabular.tools.data_gen as datagen
 from nvtabular import ops
 from nvtabular.io.dataset import Dataset
-from tests.conftest import mycols_csv, mycols_pq
+from tests.conftest import assert_eq, mycols_csv, mycols_pq
 
 # If pytorch isn't installed skip these tests. Note that the
 # torch_dataloader import needs to happen after this line

--- a/tests/unit/test_triton_inference.py
+++ b/tests/unit/test_triton_inference.py
@@ -8,10 +8,10 @@ from distutils.spawn import find_executable
 import cudf
 import numpy as np
 import pytest
-from cudf.tests.utils import assert_eq
 
 import nvtabular as nvt
 import nvtabular.ops as ops
+from tests.conftest import assert_eq
 
 triton = pytest.importorskip("nvtabular.inference.triton")
 grpcclient = pytest.importorskip("tritonclient.grpc")

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -24,12 +24,11 @@ import dask_cudf
 import numpy as np
 import pandas as pd
 import pytest
-from cudf.tests.utils import assert_eq
 from pandas.api.types import is_integer_dtype
 
 import nvtabular as nvt
 from nvtabular import ColumnGroup, Dataset, Workflow, ops
-from tests.conftest import get_cats, mycols_csv
+from tests.conftest import assert_eq, get_cats, mycols_csv
 
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1])


### PR DESCRIPTION
in cudf 21.08 assert_eq has been moved to cudf.testing._utils. Fix our unittests
so they work with both cudf 21.06 and 21.08
