### PR TITLE
Update triton model.py to use dict array representations

### DIFF
--- a/nvtabular/inference/triton/data_conversions.py
+++ b/nvtabular/inference/triton/data_conversions.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import itertools
+
+try:
+    import cudf
+    import cupy as cp
+except ImportError:
+    cudf = cp = None
+
+import numpy as np
+import pandas as pd
+
+from nvtabular.dispatch import _build_cudf_list_column
+from nvtabular.ops.operator import Supports
+
+
+def convert_format(tensors, kind, target_kind):
+    """Converts data from format 'kind' to one of the formats specified in 'target_kind'
+    This allows us to convert data to/from dataframe representations for operators that
+    only support certain reprentations
+    """
+
+    # this is all much more difficult because of multihot columns, which don't have
+    # great representations in dicts of cpu/gpu arrays. we're representing multihots
+    # as tuples of (values, offsets) tensors in this case - but have to do work at
+    # each step in terms of converting.
+    if kind & target_kind:
+        return tensors, kind
+
+    elif target_kind & Supports.GPU_DICT_ARRAY:
+        if kind == Supports.CPU_DICT_ARRAY:
+            return _convert_array(tensors, cp.array), Supports.GPU_DICT_ARRAY
+        elif kind == Supports.CPU_DATAFRAME:
+            return _pandas_to_array(tensors, False), Supports.GPU_DICT_ARRAY
+        elif kind == Supports.GPU_DATAFRAME:
+            return _cudf_to_array(tensors, False), Supports.GPU_DICT_ARRAY
+
+    elif target_kind & Supports.CPU_DICT_ARRAY:
+        if kind == Supports.GPU_DICT_ARRAY:
+            return _convert_array(tensors, cp.asnumpy), Supports.CPU_DICT_ARRAY
+        elif kind == Supports.CPU_DATAFRAME:
+            return _pandas_to_array(tensors, True), Supports.CPU_DICT_ARRAY
+        elif kind == Supports.GPU_DATAFRAME:
+            return _cudf_to_array(tensors, True), Supports.CPU_DICT_ARRAY
+
+    elif target_kind & Supports.GPU_DATAFRAME:
+        if kind == Supports.CPU_DATAFRAME:
+            return cudf.DataFrame(tensors), Supports.GPU_DATAFRAME
+        return _array_to_cudf(tensors), Supports.GPU_DATAFRAME
+
+    elif target_kind & Supports.CPU_DATAFRAME:
+        if kind == Supports.GPU_DATAFRAME:
+            return tensors.to_pandas(), Supports.CPU_DATAFRAME
+        elif kind == Supports.CPU_DICT_ARRAY:
+            return _array_to_pandas(tensors), Supports.CPU_DATAFRAME
+        elif kind == Supports.GPU_DICT_ARRAY:
+            return _array_to_pandas(_convert_array(tensors, cp.asnumpy)), Supports.CPU_DATAFRAME
+
+    raise ValueError("unsupported target for converting tensors", target_kind)
+
+
+def _convert_array(tensors, converter):
+    output = {}
+    for name, tensor in tensors.items():
+        if isinstance(tensor, tuple):
+            output[name] = tuple(converter(t) for t in tensor)
+        else:
+            output[name] = converter(tensor)
+    return output
+
+
+def _array_to_pandas(tensors):
+    output = pd.DataFrame()
+    for name, tensor in tensors.items():
+        if isinstance(tensor, tuple):
+            values, offsets = tensor
+            output[name] = [values[offsets[i] : offsets[i + 1]] for i in range(len(offsets) - 1)]
+        else:
+            output[name] = tensor
+    return output
+
+
+def _array_to_cudf(tensors):
+    output = cudf.DataFrame()
+    for name, tensor in tensors.items():
+        if isinstance(tensor, tuple):
+            output[name] = _build_cudf_list_column(tensor[0], tensor[1].astype("int32"))
+        else:
+            output[name] = tensor
+    return output
+
+
+def _pandas_to_array(df, cpu=True):
+    array_type = np.array if cpu else cp.array
+
+    output = {}
+    for name in df.columns:
+        col = df[name]
+        if pd.api.types.is_list_like(col.values[0]):
+            offsets = pd.Series([0]).append(col.map(len).cumsum()).values
+            if not cpu:
+                offsets = cp.array(offsets)
+            values = array_type(list(itertools.chain(*col)))
+            output[name] = (values, offsets)
+        else:
+            values = col.values
+            if not cpu:
+                values = cp.array(values)
+            output[name] = values
+
+    return output
+
+
+def _cudf_to_array(df, cpu=True):
+    output = {}
+    for name in df.columns:
+        col = df[name]
+        if cudf.utils.dtypes.is_list_dtype(col.dtype):
+            offsets = col._column.offsets.values_host if cpu else col._column.offsets.values
+            values = col.list.leaves.values_host if cpu else col.list.leaves.values
+            output[name] = (values, offsets)
+        else:
+            output[name] = col.values_host if cpu else col.values
+
+    return output

--- a/nvtabular/inference/triton/model.py
+++ b/nvtabular/inference/triton/model.py
@@ -138,7 +138,6 @@ class TritonPythonModel:
                 transformed, kind = convert_format(transformed, kind, Supports.CPU_DICT_ARRAY)
 
             # convert to the format expected by the DL models
-            response = self._transform_outputs(transformed)
             if self.output_model == "hugectr":
                 response = self._transform_hugectr_outputs(transformed)
             else:

--- a/nvtabular/inference/triton/model.py
+++ b/nvtabular/inference/triton/model.py
@@ -25,12 +25,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import logging
 import os
 from typing import List
 
-import cudf
 import numpy as np
-from cudf.core.column import as_column, build_column
 from cudf.utils.dtypes import is_list_dtype
 from triton_python_backend_utils import (
     InferenceRequest,
@@ -42,7 +41,12 @@ from triton_python_backend_utils import (
 )
 
 import nvtabular
-from nvtabular.inference.triton import _convert_tensor, get_column_types
+from nvtabular.dispatch import _concat_columns
+from nvtabular.inference.triton import get_column_types
+from nvtabular.inference.triton.data_conversions import convert_format
+from nvtabular.ops.operator import Supports
+
+LOG = logging.getLogger("nvtabular")
 
 
 class TritonPythonModel:
@@ -113,77 +117,71 @@ class TritonPythonModel:
         """
         responses = []
         for request in requests:
-            # create a cudf DataFrame from the triton request
-            input_df = cudf.DataFrame(
-                {
-                    name: _convert_tensor(get_input_tensor_by_name(request, name))
-                    for name in self.input_dtypes
-                }
-            )
+            # transform the triton tensors to a dict of name:numpy tensor
+            input_tensors = {
+                name: get_input_tensor_by_name(request, name).as_numpy().squeeze()
+                for name in self.input_dtypes
+            }
 
+            # multihots are represented as a tuple of (values, offsets)
             for name, dtype in self.input_multihots.items():
-                values = as_column(
-                    _convert_tensor(get_input_tensor_by_name(request, name + "__values"))
-                )
-                nnzs = as_column(
-                    _convert_tensor(get_input_tensor_by_name(request, name + "__nnzs"))
-                )
-                input_df[name] = build_column(
-                    None, dtype=dtype, size=nnzs.size - 1, children=(nnzs, values)
-                )
+                values = get_input_tensor_by_name(request, name + "__values").as_numpy().squeeze()
+                offsets = get_input_tensor_by_name(request, name + "__nnzs").as_numpy().squeeze()
+                input_tensors[name] = (values, offsets)
 
             # use our NVTabular workflow to transform the dataframe
-            output_df = nvtabular.workflow._transform_partition(
-                input_df, [self.workflow.column_group]
-            )
+            transformed, kind = _transform_tensors(input_tensors, self.workflow.column_group)
 
-            # convert back to a triton response
+            # if we don't have tensors in numpy format, convert back so that the we can return
+            # to triton
+            if kind != Supports.CPU_DICT_ARRAY:
+                transformed, kind = convert_format(transformed, kind, Supports.CPU_DICT_ARRAY)
+
+            # convert to the format expected by the DL models
+            response = self._transform_outputs(transformed)
             if self.output_model == "hugectr":
-                response = self._transform_hugectr_outputs(output_df)
+                response = self._transform_hugectr_outputs(transformed)
             else:
-                response = self._transform_outputs(output_df)
+                response = self._transform_outputs(transformed)
             responses.append(response)
 
         return responses
 
-    def _transform_outputs(self, output_df):
+    def _transform_outputs(self, tensors):
         """ transforms outputs for both pytorch and tensorflow """
         output_tensors = []
-        for name in output_df.columns:
-            col = output_df[name]
-            if is_list_dtype(col.dtype):
+        for name, value in tensors.items():
+            if isinstance(value, tuple):
                 # convert list values to match TF dataloader
-                values = col.list.leaves.values_host.astype(self.output_dtypes[name + "__values"])
+                values = value[0].astype(self.output_dtypes[name + "__values"])
                 values = values.reshape(len(values), 1)
                 output_tensors.append(Tensor(name + "__values", values))
 
-                offsets = col._column.offsets.values_host.astype(
-                    self.output_dtypes[name + "__nnzs"]
-                )
+                offsets = value[1].astype(self.output_dtypes[name + "__nnzs"])
                 nnzs = offsets[1:] - offsets[:-1]
                 nnzs = nnzs.reshape(len(nnzs), 1)
                 output_tensors.append(Tensor(name + "__nnzs", nnzs))
             else:
-                d = col.values_host.astype(self.output_dtypes[name])
+                d = value.astype(self.output_dtypes[name])
                 d = d.reshape(len(d), 1)
                 output_tensors.append(Tensor(name, d))
         return InferenceResponse(output_tensors)
 
-    def _transform_hugectr_outputs(self, output_df):
+    def _transform_hugectr_outputs(self, tensors):
         output_tensors = []
         if "conts" in self.column_types:
             output_tensors.append(
                 Tensor(
                     "DES",
-                    _convert_to_hugectr(output_df[self.column_types["conts"]], np.float32),
+                    _convert_to_hugectr(self.column_types["conts"], tensors, np.float32),
                 )
             )
         else:
             output_tensors.append(Tensor("DES", np.array([[]], np.float32)))
 
         if "cats" in self.column_types:
-            output_df[self.column_types["cats"]] += self.offsets
-            cats_np = _convert_to_hugectr(output_df[self.column_types["cats"]], np.int64)
+            cats_np = _convert_to_hugectr(self.column_types["cats"], tensors, np.int64)
+            cats_np += self.offsets
             output_tensors.append(
                 Tensor(
                     "CATCOLUMN",
@@ -200,13 +198,13 @@ class TritonPythonModel:
         return InferenceResponse(output_tensors)
 
 
-def _convert_to_hugectr(df, dtype):
+def _convert_to_hugectr(columns, tensors, dtype):
     """ converts a dataframe to a numpy input compatible with hugectr """
-    d = np.empty(df.shape)
-    for i, name in enumerate(df.columns):
-        d[:, i] = df[name].values_host
-
-    return d.reshape(1, df.shape[0] * df.shape[1]).astype(dtype)
+    rows = max(len(tensors[name]) for name in columns)
+    d = np.empty((rows, len(columns)), dtype=dtype)
+    for i, name in enumerate(columns):
+        d[:, i] = tensors[name].astype(dtype)
+    return d.reshape(1, len(columns) * rows)
 
 
 def get_hugectr_offsets(path):
@@ -218,3 +216,52 @@ def get_hugectr_offsets(path):
         return np.cumsum(np.array(slot_sizes)).tolist()
     else:
         return None
+
+
+def _transform_tensors(input_tensors, column_group):
+    if column_group.parents:
+        tensors, kind = None, None
+        for parent in column_group.parents:
+            transformed, transformed_kind = _transform_tensors(input_tensors, parent)
+            if tensors is None:
+                tensors, kind = transformed, transformed_kind
+            else:
+                if kind != transformed_kind:
+                    # we have multiple different kinds of data here (dataframe/array on cpu/gpu)
+                    # we need to convert to a common format here first before concatentating.
+                    op = column_group.op
+                    target_kind = op.supports if op else Supports.CPU_DICT_ARRAY
+                    # note : the 2nd convert_tensors call needs to be stricter in what the kind is
+                    # (exact match rather than a bitmask of values)
+                    tensors, kind = convert_format(tensors, kind, target_kind)
+                    transformed, _ = convert_format(transformed, transformed_kind, kind)
+
+                _concat_tensors([tensors, transformed], kind)
+
+    else:
+        tensors = {c: input_tensors[c] for c in column_group.columns}
+        kind = Supports.CPU_DICT_ARRAY
+
+    if column_group.op:
+        try:
+            # if the op doesn't support the current kind - we need to convert
+            if not column_group.op.supports & kind:
+                tensors, kind = convert_format(tensors, kind, column_group.op.supports)
+
+            tensors = column_group.op.transform(column_group.columns, tensors)
+
+        except Exception:
+            LOG.exception("Failed to transform operator %s", column_group.op)
+            raise
+
+    return tensors, kind
+
+
+def _concat_tensors(tensors, kind):
+    if kind & (Supports.GPU_DATAFRAME | Supports.CPU_DATAFRAME):
+        return _concat_columns(tensors)
+    else:
+        output = tensors[0]
+        for tensor in tensors[1:]:
+            output.update(tensor)
+        return output

--- a/nvtabular/inference/triton/model.py
+++ b/nvtabular/inference/triton/model.py
@@ -129,7 +129,7 @@ class TritonPythonModel:
                 offsets = _convert_tensor(get_input_tensor_by_name(request, name + "__nnzs"))
                 input_tensors[name] = (values, offsets)
 
-            # use our NVTabular workflow to transform the dataframe
+            # use our NVTabular workflow to transform the dataset
             transformed, kind = _transform_tensors(input_tensors, self.workflow.column_group)
 
             # if we don't have tensors in numpy format, convert back so that the we can return
@@ -198,7 +198,7 @@ class TritonPythonModel:
 
 
 def _convert_to_hugectr(columns, tensors, dtype):
-    """ converts a dataframe to a numpy input compatible with hugectr """
+    """ converts outputs to a numpy input compatible with hugectr """
     rows = max(len(tensors[name]) for name in columns)
     d = np.empty((rows, len(columns)), dtype=dtype)
     for i, name in enumerate(columns):

--- a/tests/unit/test_triton_inference.py
+++ b/tests/unit/test_triton_inference.py
@@ -226,7 +226,6 @@ def test_convert_format(_from, _to):
 
     start, kind = convert_format(df, Supports.CPU_DATAFRAME, _from)
     assert kind == _from
-    print(start, kind, _to)
     mid, kind = convert_format(start, kind, _to)
     assert kind == _to
     final, kind = convert_format(mid, kind, Supports.CPU_DATAFRAME)

--- a/tests/unit/test_triton_inference.py
+++ b/tests/unit/test_triton_inference.py
@@ -7,13 +7,17 @@ from distutils.spawn import find_executable
 
 import cudf
 import numpy as np
+import pandas as pd
 import pytest
 
 import nvtabular as nvt
 import nvtabular.ops as ops
+from nvtabular.ops.operator import Supports
 from tests.conftest import assert_eq
 
 triton = pytest.importorskip("nvtabular.inference.triton")
+data_conversions = pytest.importorskip("nvtabular.inference.triton.data_conversions")
+
 grpcclient = pytest.importorskip("tritonclient.grpc")
 tritonclient = pytest.importorskip("tritonclient")
 
@@ -201,3 +205,30 @@ def test_generate_triton_model(tmpdir, engine, df):
     transformed = workflow.transform(nvt.Dataset(df)).to_ddf().compute()
 
     assert_eq(expected, transformed)
+
+
+# lets test the data format conversion function on the full cartesian product
+# of the Support flags
+@pytest.mark.parametrize("_from", list(Supports))
+@pytest.mark.parametrize("_to", list(Supports))
+def test_convert_format(_from, _to):
+    convert_format = data_conversions.convert_format
+
+    # we want to test conversion from '_from' to '_to' but this requires us roundtripping
+    # from a known format. I'm picking pd -> _from -> _to -> pandas somewhat arbitrarily
+    df = pd.DataFrame(
+        {"float": [0.0, 1.0, 2.0], "int": [10, 11, 12], "multihot": [[0, 1, 2, 3], [3, 4], [5]]}
+    )
+
+    if _from != Supports.GPU_DICT_ARRAY and _to != Supports.GPU_DICT_ARRAY:
+        df["string"] = ["aa", "bb", "cc"]
+        df["multihot_string"] = [["aaaa", "bb", "cc"], ["dd", "ee"], ["fffffff"]]
+
+    start, kind = convert_format(df, Supports.CPU_DATAFRAME, _from)
+    assert kind == _from
+    print(start, kind, _to)
+    mid, kind = convert_format(start, kind, _to)
+    assert kind == _to
+    final, kind = convert_format(mid, kind, Supports.CPU_DATAFRAME)
+    assert kind == Supports.CPU_DATAFRAME
+    assert_eq(df, final)


### PR DESCRIPTION
Update the triton model.py to use dict representations of operators when allowed
(CPU_DICT_ARRAY or GPU_DICT_ARRAY).  This allows us to avoid representing
data in a dataframe format entirely at inference time and enables future optimizations.
This is the 2nd of 3 PR's to enable small batch optimizations for inference.
