### PR TITLE
Fix for running on CPU only systems

### DIFF
--- a/nvtabular/worker.py
+++ b/nvtabular/worker.py
@@ -83,7 +83,7 @@ def fetch_table_data(
             if reader == _lib.read_parquet:  # pylint: disable=comparison-with-callable
                 # Using cudf-backed data with "host" caching.
                 # Cache as an Arrow table.
-                with fsspec.open(path, "rb") as f:
+                with contextlib.closing(fsspec.open(path, "rb")) as f:
                     table = reader(f, **use_kwargs)
                 if cudf:
                     table_cache[path] = table.to_arrow()


### PR DESCRIPTION
On my macbook and on the linux github actions CI, ``` pytest tests/unit/test_cpu_workflow.py```
fails with:

```
ERROR    nvtabular:workflow.py:366 Failed to transform operator <nvtabular.ops.categorify.Categorify object at 0x7fbed7cdc2b0>
Traceback (most recent call last):
  File "/Users/benf/code/nvtabular/nvtabular/ops/categorify.py", line 395, in transform
    new_df[name] = _encode(
  File "/Users/benf/code/nvtabular/nvtabular/ops/categorify.py", line 998, in _encode
    value = fetch_table_data(
  File "/Users/benf/code/nvtabular/nvtabular/worker.py", line 89, in fetch_table_data
    table = reader(f, **use_kwargs)
  File "/Users/benf/miniconda3/lib/python3.9/site-packages/pandas/io/parquet.py", line 459, in read_parquet
    return impl.read(
  File "/Users/benf/miniconda3/lib/python3.9/site-packages/pandas/io/parquet.py", line 221, in read
    return self.api.parquet.read_table(
  File "/Users/benf/miniconda3/lib/python3.9/site-packages/pyarrow/parquet.py", line 1700, in read_table
    dataset = _ParquetDatasetV2(
  File "/Users/benf/miniconda3/lib/python3.9/site-packages/pyarrow/parquet.py", line 1558, in __init__
    self._dataset = ds.dataset(path_or_paths, filesystem=filesystem,
  File "/Users/benf/miniconda3/lib/python3.9/site-packages/pyarrow/dataset.py", line 657, in dataset
    return _filesystem_dataset(source, **kwargs)
  File "/Users/benf/miniconda3/lib/python3.9/site-packages/pyarrow/dataset.py", line 402, in _filesystem_dataset
    fs, paths_or_selector = _ensure_single_source(source, filesystem)
  File "/Users/benf/miniconda3/lib/python3.9/site-packages/pyarrow/dataset.py", line 378, in _ensure_single_source
    raise FileNotFoundError(path)
FileNotFoundError: <fsspec.implementations.local.LocalFileOpener object at 0x7fbeb9a990d0>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/benf/code/nvtabular/nvtabular/workflow.py", line 364, in _transform_partition
    df = column_group.op.transform(column_group.input_column_names, df)
  File "/Users/benf/code/nvtabular/nvtabular/dispatch.py", line 54, in inner2
    return func(*args, **kwargs)
  File "/Users/benf/code/nvtabular/nvtabular/ops/categorify.py", line 413, in transform
    raise RuntimeError(f"Failed to categorical encode column {name}") from e
RuntimeError: Failed to categorical encode column name-string
```

This seems to be a result of how fsspec.open interacts with pandas. When fsspec.open is called
as a context manager it returns a ```fsspec.implementations.local.LocalFileOpener``` object which
fails with pandas. However when not run as a context manager (just fsspec.open) it returns a
```fsspec.core.OpenFile``` object which works.

Work around this issue by not using the fsspec contextmanager, and use one from contextlib instead.

After this change I can run ``` pytest tests/unit/test_cpu_workflow.py``` on my macbook to test cpu
only capabalities.

<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
