### PR TITLE
Add versioneer to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas>=1.0,<1.3.0dev0
 numba>=0.53.1
 tdqm
 pyarrow
+versioneer


### PR DESCRIPTION
Saw a CPU CI failure with a ```ModuleNotFoundError: No module named 'versioneer'``` error.
https://github.com/NVIDIA/NVTabular/runs/3063229666 . Try to fix with installing versioneer

