### PR TITLE
Fix triton concatenating dataframes

### DIFF
--- a/nvtabular/inference/triton/model.py
+++ b/nvtabular/inference/triton/model.py
@@ -235,7 +235,7 @@ def _transform_tensors(input_tensors, column_group):
                     tensors, kind = convert_format(tensors, kind, target_kind)
                     transformed, _ = convert_format(transformed, transformed_kind, kind)
 
-                _concat_tensors([tensors, transformed], kind)
+                tensors = _concat_tensors([tensors, transformed], kind)
 
     else:
         tensors = {c: input_tensors[c] for c in column_group.columns}


### PR DESCRIPTION
There was a bug in the triton model.py file where dataframes weren't getting
concatenated appropriately.  This didn't happen with the dict representation
causing this to get missed during manual testing.

Fix and add a unittest that would catch this.
