### PR TITLE
Automatically detect Dask client in Workflow and Dataset

### DIFF
--- a/nvtabular/io/dataset.py
+++ b/nvtabular/io/dataset.py
@@ -31,6 +31,7 @@ from fsspec.utils import stringify_path
 
 from nvtabular.dispatch import _convert_data, _hex_to_int, _is_dataframe_object
 from nvtabular.io.shuffle import _check_shuffle_arg
+from nvtabular.utils import set_dask_client
 
 from ..utils import device_mem_size
 from .csv import CSVDatasetEngine
@@ -194,6 +195,12 @@ class Dataset:
         Optional reference to the original "base" Dataset object used
         to construct the current Dataset instance.  This object is
         used to preserve file-partition mapping information.
+    client : distributed.Client or bool, optional
+        Optional Dask-Distributed Client object to use for graph
+        execution.  By default (True), an existing Dask client will
+        be detected automatically.  If a client is not detected, or if
+        `client` is set to `False`, Dask's single-threaded scheduler
+        will be used.
     """
 
     def __init__(
@@ -205,13 +212,13 @@ class Dataset:
         part_mem_fraction=None,
         storage_options=None,
         dtypes=None,
-        client=None,
+        client=True,
         cpu=None,
         base_dataset=None,
         **kwargs,
     ):
         self.dtypes = dtypes
-        self.client = client
+        self.client = set_dask_client(client)
 
         # Check if we are keeping data in cpu memory
         self.cpu = cpu

--- a/nvtabular/utils.py
+++ b/nvtabular/utils.py
@@ -23,6 +23,7 @@ import zipfile
 
 import dask
 from dask.dataframe.optimize import optimize as dd_optimize
+from dask.distributed import get_client
 from tqdm import tqdm
 
 try:
@@ -156,3 +157,14 @@ def _ensure_optimize_dataframe_graph(ddf=None, dsk=None, keys=None):
     # Return optimized ddf
     ddf.dask = dsk
     return ddf
+
+
+def set_dask_client(client):
+    # Check for distributed client.
+    # Use `get_client` if `cleint==True`
+    if client is True:
+        try:
+            return get_client()
+        except ValueError:
+            return None
+    return client

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -19,7 +19,7 @@ import os
 import sys
 import time
 import warnings
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 import cloudpickle
 
@@ -35,7 +35,7 @@ from nvtabular.column_group import ColumnGroup, _merge_add_nodes, iter_nodes
 from nvtabular.dispatch import _concat_columns
 from nvtabular.io.dataset import Dataset
 from nvtabular.ops import StatOperator
-from nvtabular.utils import _ensure_optimize_dataframe_graph
+from nvtabular.utils import _ensure_optimize_dataframe_graph, set_dask_client
 from nvtabular.worker import clean_worker_cache
 
 LOG = logging.getLogger("nvtabular")
@@ -70,13 +70,18 @@ class Workflow:
     ----------
     column_group: ColumnGroup
         The graph of operators this workflow should apply
-    client: distributed.Client, optional
-        The Dask distributed client to use for multi-gpu processing and multi-node processing
+    client: distributed.Client or bool, optional
+        The Dask distributed client to use for multi-gpu processing and multi-node processing.
+        By default (True), an existing Dask client will be detected automatically.  If a client
+        is not detected, or if `client` is set to `False`, Dask's single-threaded scheduler
+        will be used.
     """
 
-    def __init__(self, column_group: ColumnGroup, client: Optional["distributed.Client"] = None):
+    def __init__(
+        self, column_group: ColumnGroup, client: Optional[Union["distributed.Client", bool]] = True
+    ):
         self.column_group = _merge_add_nodes(column_group)
-        self.client = client
+        self.client = set_dask_client(client)
         self.input_dtypes = None
         self.output_dtypes = None
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -224,7 +224,7 @@ def test_dask_datframe_methods(tmpdir, cpu):
 def test_hugectr(
     tmpdir, client, df, dataset, output_format, engine, op_columns, num_io_threads, use_client
 ):
-    client = client if use_client else None
+    client = client if use_client else False
 
     cat_names = ["name-cat", "name-string"] if engine == "parquet" else ["name-string"]
     cont_names = ["x", "y"]
@@ -240,7 +240,7 @@ def test_hugectr(
     conts = nvt.ColumnGroup(cont_names) >> ops.Normalize
     cats = nvt.ColumnGroup(cat_names) >> ops.Categorify
 
-    workflow = nvt.Workflow(conts + cats + label_names)
+    workflow = nvt.Workflow(conts + cats + label_names, client=client)
     transformed = workflow.fit_transform(dataset)
 
     if output_format == "hugectr":


### PR DESCRIPTION
NVTabular currently requires a distributed Client object to be specified explicitly when a new `Workflow` and/or `Dataset` object are constructed.  This does not really align with conventional Dask-collection behavior, where the client will be automatically detected when compute/persist is called.  This PR adds the necessary logic to autodetect a Dask cleint within the `Workflow` and `Dataset` constructors.

Some open questions:

- What do we want the `client` argument options and defaults to be? This PR currently allows the user to specify an explicit client, or a `bool` to reflect whether or not a client should be automatically detected.
- Should this auto-detection logic even live in the constructor, or should we be detecting the client when compute is internally called within NVTabular (allowing users to spin up a cluster after the workflow/Dataset are defined)?

<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
