### PR TITLE
Add test_triton_inference to CPU ci

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -42,7 +42,7 @@ jobs:
         isort -c .
     - name: Build
       run: |
-        python setup.py develop
+        python setup.py develop --user
     - name: Run unittests
       run: |
         python -m pytest -rxs tests/unit/test_cpu_workflow.py tests/unit/test_column_group.py tests/unit/test_ops.py tests/unit/test_triton_inference.py

--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -27,8 +27,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel 
+        python -m pip install nvidia-pyindex
         python -m pip install -r requirements.txt pybind11
         python -m pip install -r requirements-dev.txt
+        python -m pip install tritonclient
     - name: Lint with flake8
       run: |
         flake8 .

--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install nvidia-pyindex
         python -m pip install -r requirements.txt pybind11
         python -m pip install -r requirements-dev.txt
-        python -m pip install tritonclient
+        python -m pip install tritonclient[all] protobuf
     - name: Lint with flake8
       run: |
         flake8 .

--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -43,4 +43,4 @@ jobs:
         python setup.py develop
     - name: Run unittests
       run: |
-        python -m pytest tests/unit/test_cpu_workflow.py tests/unit/test_column_group.py tests/unit/test_ops.py tests/unit/test_triton_inference.py
+        python -m pytest -rxs tests/unit/test_cpu_workflow.py tests/unit/test_column_group.py tests/unit/test_ops.py tests/unit/test_triton_inference.py

--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -43,4 +43,4 @@ jobs:
         python setup.py develop
     - name: Run unittests
       run: |
-        python -m pytest tests/unit/test_cpu_workflow.py tests/unit/test_column_group.py tests/unit/test_ops.py
+        python -m pytest tests/unit/test_cpu_workflow.py tests/unit/test_column_group.py tests/unit/test_ops.py tests/unit/test_triton_inference.py

--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -37,4 +37,4 @@ echo "Building docs"
 make -C docs html SPHINXOPTS="-W -q"
 
 # test out our codebase
-py.test --cov-config tests/unit/.coveragerc --cov-report term-missing --cov-report xml --cov-fail-under 70 --cov=. tests/unit/
+py.test -rsx --cov-config tests/unit/.coveragerc --cov-report term-missing --cov-report xml --cov-fail-under 70 --cov=. tests/unit/

--- a/nvtabular/dispatch.py
+++ b/nvtabular/dispatch.py
@@ -29,7 +29,7 @@ try:
     import cupy as cp
     import dask_cudf
     from cudf.core.column import as_column, build_column
-    from cudf.utils.dtypes import is_list_dtype
+    from cudf.utils.dtypes import is_list_dtype, is_string_dtype
 
     HAS_GPU = True
 except ImportError:
@@ -201,6 +201,13 @@ def _is_list_dtype(ser):
             return False
         return pd.api.types.is_list_like(ser.values[0])
     return is_list_dtype(ser)
+
+
+def _is_string_dtype(obj):
+    if not HAS_GPU:
+        return pd.api.types.is_string_dtype(obj)
+    else:
+        return is_string_dtype(obj)
 
 
 def _flatten_list_column(s):

--- a/nvtabular/inference/triton/__init__.py
+++ b/nvtabular/inference/triton/__init__.py
@@ -18,12 +18,15 @@ import json
 import os
 from shutil import copyfile
 
-import tritonclient.grpc as grpcclient
-from google.protobuf import text_format
-from tritonclient.utils import np_to_triton_dtype
+# this needs to be before any modules that import protobuf
+os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
-import nvtabular.inference.triton.model_config_pb2 as model_config
-from nvtabular.dispatch import _is_list_dtype, _is_string_dtype, _make_df
+import tritonclient.grpc as grpcclient  # noqa
+from google.protobuf import text_format  # noqa
+from tritonclient.utils import np_to_triton_dtype  # noqa
+
+import nvtabular.inference.triton.model_config_pb2 as model_config  # noqa
+from nvtabular.dispatch import _is_list_dtype, _is_string_dtype, _make_df  # noqa
 
 
 def export_tensorflow_ensemble(

--- a/nvtabular/inference/triton/model.py
+++ b/nvtabular/inference/triton/model.py
@@ -30,7 +30,6 @@ import os
 from typing import List
 
 import numpy as np
-from cudf.utils.dtypes import is_list_dtype
 from triton_python_backend_utils import (
     InferenceRequest,
     InferenceResponse,
@@ -41,7 +40,7 @@ from triton_python_backend_utils import (
 )
 
 import nvtabular
-from nvtabular.dispatch import _concat_columns
+from nvtabular.dispatch import _concat_columns, _is_list_dtype
 from nvtabular.inference.triton import _convert_tensor, get_column_types
 from nvtabular.inference.triton.data_conversions import convert_format
 from nvtabular.ops.operator import Supports
@@ -82,15 +81,15 @@ class TritonPythonModel:
         self.input_dtypes = {
             col: dtype
             for col, dtype in self.workflow.input_dtypes.items()
-            if not is_list_dtype(dtype)
+            if not _is_list_dtype(dtype)
         }
         self.input_multihots = {
-            col: dtype for col, dtype in self.workflow.input_dtypes.items() if is_list_dtype(dtype)
+            col: dtype for col, dtype in self.workflow.input_dtypes.items() if _is_list_dtype(dtype)
         }
 
         self.output_dtypes = dict()
         for name, dtype in self.workflow.output_dtypes.items():
-            if not is_list_dtype(dtype):
+            if not _is_list_dtype(dtype):
                 self._set_output_dtype(name)
             else:
                 # pytorch + hugectr don't support multihot output features at inference

--- a/setup.py
+++ b/setup.py
@@ -101,5 +101,5 @@ setup(
     cmdclass=cmdclass,
     ext_modules=ext_modules,
     zip_safe=False,
-    #    install_requires=install_reqs,
+    install_requires=install_reqs,
 )

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ import versioneer
 
 class build_proto(_build_py):
     def run(self):
+        print("running build_proto")
         protoc = None
         if "PROTOC" in os.environ and os.path.exists(os.environ["PROTOC"]):
             protoc = os.environ["PROTOC"]
@@ -50,6 +51,8 @@ class build_proto(_build_py):
                 print("Generating", output, "from", source)
                 cmd = [protoc, f"--python_out={pwd}", f"--proto_path={pwd}", source]
                 subprocess.check_call(cmd, env=env)
+            else:
+                print("not generating", output)
 
         _build_py.run(self)
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@
 import os
 import subprocess
 import sys
-from distutils.command.build_py import build_py as _build_py
 from distutils.spawn import find_executable
 
 from pybind11.setup_helpers import Pybind11Extension
@@ -26,9 +25,9 @@ from setuptools import find_packages, setup
 import versioneer
 
 
-class build_proto(_build_py):
+class build_pybind_and_proto(build_pybind11):
     def run(self):
-        print("running build_proto")
+        build_pybind11.run(self)
         protoc = None
         if "PROTOC" in os.environ and os.path.exists(os.environ["PROTOC"]):
             protoc = os.environ["PROTOC"]
@@ -52,9 +51,7 @@ class build_proto(_build_py):
                 cmd = [protoc, f"--python_out={pwd}", f"--proto_path={pwd}", source]
                 subprocess.check_call(cmd, env=env)
             else:
-                print("not generating", output)
-
-        _build_py.run(self)
+                print("not regenerating", output, " - file exists and proto hasn't been updated")
 
 
 ext_modules = [
@@ -73,8 +70,7 @@ ext_modules = [
 
 
 cmdclass = versioneer.get_cmdclass()
-cmdclass["build_ext"] = build_pybind11
-cmdclass["build_py"] = build_proto
+cmdclass["build_ext"] = build_pybind_and_proto
 
 
 def parse_requirements(filename):
@@ -105,5 +101,5 @@ setup(
     cmdclass=cmdclass,
     ext_modules=ext_modules,
     zip_safe=False,
-    install_requires=install_reqs,
+    #    install_requires=install_reqs,
 )

--- a/tests/unit/test_triton_inference.py
+++ b/tests/unit/test_triton_inference.py
@@ -5,13 +5,13 @@ import subprocess
 import time
 from distutils.spawn import find_executable
 
-import cudf
 import numpy as np
 import pandas as pd
 import pytest
 
 import nvtabular as nvt
 import nvtabular.ops as ops
+from nvtabular.dispatch import HAS_GPU, _make_df
 from nvtabular.ops.operator import Supports
 from tests.conftest import assert_eq
 
@@ -83,13 +83,13 @@ def _verify_workflow_on_tritonserver(tmpdir, workflow, df, model_name):
 
         for col in df.columns:
             features = response.as_numpy(col)
-            triton_df = cudf.DataFrame({col: features.reshape(features.shape[0])})
+            triton_df = _make_df({col: features.reshape(features.shape[0])})
             assert_eq(triton_df, local_df[[col]])
 
 
 @pytest.mark.skipif(TRITON_SERVER_PATH is None, reason="Requires tritonserver on the path")
 def test_error_handling(tmpdir):
-    df = cudf.DataFrame({"x": np.arange(10), "y": np.arange(10)})
+    df = _make_df({"x": np.arange(10), "y": np.arange(10)})
 
     def custom_transform(col):
         if len(col) == 2:
@@ -115,7 +115,7 @@ def test_error_handling(tmpdir):
 
 @pytest.mark.skipif(TRITON_SERVER_PATH is None, reason="Requires tritonserver on the path")
 def test_tritonserver_inference_string(tmpdir):
-    df = cudf.DataFrame({"user": ["aaaa", "bbbb", "cccc", "aaaa", "bbbb", "aaaa"]})
+    df = _make_df({"user": ["aaaa", "bbbb", "cccc", "aaaa", "bbbb", "aaaa"]})
     features = ["user"] >> ops.Categorify()
     workflow = nvt.Workflow(features)
     _verify_workflow_on_tritonserver(tmpdir, workflow, df, "test_inference_string")
@@ -124,7 +124,7 @@ def test_tritonserver_inference_string(tmpdir):
 @pytest.mark.skipif(TRITON_SERVER_PATH is None, reason="Requires tritonserver on the path")
 def test_large_strings(tmpdir):
     strings = ["a" * (2 ** exp) for exp in range(1, 17)]
-    df = cudf.DataFrame({"description": strings})
+    df = _make_df({"description": strings})
     features = ["description"] >> ops.Categorify()
     workflow = nvt.Workflow(features)
     _verify_workflow_on_tritonserver(tmpdir, workflow, df, "test_large_string")
@@ -134,7 +134,7 @@ def test_large_strings(tmpdir):
 def test_concatenate_dataframe(tmpdir):
     # we were seeing an issue in the rossmann workflow where we dropped certain columns,
     # https://github.com/NVIDIA/NVTabular/issues/961
-    df = cudf.DataFrame(
+    df = _make_df(
         {
             "cat": ["aaaa", "bbbb", "cccc", "aaaa", "bbbb", "aaaa"],
             "cont": [0.0, 1.0, 2.0, 3.0, 4.0, 5],
@@ -166,7 +166,7 @@ def test_numeric_dtypes(tmpdir):
 
     # simple transform to make sure we can round-trip the min/max values for each dtype,
     # through triton, with the 'transform' here just checking that the dtypes are correct
-    df = cudf.DataFrame(
+    df = _make_df(
         {dtype: np.array([limits.max, 0, limits.min], dtype=dtype) for dtype, limits in dtypes}
     )
     features = nvt.ColumnGroup(df.columns) >> check_dtypes
@@ -175,7 +175,7 @@ def test_numeric_dtypes(tmpdir):
 
 
 def test_generate_triton_multihot(tmpdir):
-    df = cudf.DataFrame(
+    df = _make_df(
         {
             "userId": ["a", "a", "b"],
             "movieId": ["1", "2", "2"],
@@ -187,7 +187,6 @@ def test_generate_triton_multihot(tmpdir):
     workflow = nvt.Workflow(cats)
     workflow.fit(nvt.Dataset(df))
     expected = workflow.transform(nvt.Dataset(df)).to_ddf().compute()
-    print(expected)
 
     # save workflow to triton / verify we see some expected output
     repo = os.path.join(tmpdir, "models")
@@ -226,8 +225,13 @@ def test_generate_triton_model(tmpdir, engine, df):
 
 # lets test the data format conversion function on the full cartesian product
 # of the Support flags
-@pytest.mark.parametrize("_from", list(Supports))
-@pytest.mark.parametrize("_to", list(Supports))
+_SUPPORTS = list(Supports)
+if not HAS_GPU:
+    _SUPPORTS = [s for s in _SUPPORTS if "GPU" not in str(s)]
+
+
+@pytest.mark.parametrize("_from", _SUPPORTS)
+@pytest.mark.parametrize("_to", _SUPPORTS)
 def test_convert_format(_from, _to):
     convert_format = data_conversions.convert_format
 


### PR DESCRIPTION
also fix triton inference tests being skipped with ```SKIPPED [2] tests/unit/test_triton_inference.py:18: could not import 'nvtabular.inference.triton': No module named 'nvtabular.inference.triton.model_config_pb2'```
