### PR TITLE
Allow running triton inference on the CPU

### DIFF
--- a/cpp/nvtabular/inference/categorify.cc
+++ b/cpp/nvtabular/inference/categorify.cc
@@ -56,7 +56,6 @@ struct ColumnMapping {
       }
     } else {
       // TODO: array dispatch code
-      std::cout << "dtype " << dtype.kind() << column_name << std::endl;
       switch (dtype.kind()) {
         case 'f':
           switch (dtype.itemsize()) {

--- a/nvtabular/workflow.py
+++ b/nvtabular/workflow.py
@@ -258,8 +258,13 @@ class Workflow:
         lib = cudf if cudf else pd
         versions = meta["versions"]
         check_version(versions["nvtabular"], nvt_version, "nvtabular")
-        check_version(versions[lib.__name__], lib.__version__, lib.__name__)
         check_version(versions["python"], sys.version, "python")
+
+        if lib.__name__ in versions:
+            check_version(versions[lib.__name__], lib.__version__, lib.__name__)
+        else:
+            expected = "GPU" if "cudf" in versions else "CPU"
+            warnings.warn(f"Loading workflow generated on {expected}")
 
         # load up the workflow object di
         workflow = cloudpickle.load(open(os.path.join(path, "workflow.pkl"), "rb"))

--- a/tests/unit/test_triton_inference.py
+++ b/tests/unit/test_triton_inference.py
@@ -11,7 +11,7 @@ import pytest
 
 import nvtabular as nvt
 import nvtabular.ops as ops
-from nvtabular.dispatch import HAS_GPU, _make_df
+from nvtabular.dispatch import HAS_GPU, _hash_series, _make_df
 from nvtabular.ops.operator import Supports
 from tests.conftest import assert_eq
 
@@ -141,7 +141,7 @@ def test_concatenate_dataframe(tmpdir):
         }
     )
     # this bug only happened with a dataframe representation: force this by using a lambda
-    cats = ["cat"] >> ops.LambdaOp(lambda col: col.hash_values() % 1000)
+    cats = ["cat"] >> ops.LambdaOp(lambda col: _hash_series(col) % 1000)
     conts = ["cont"] >> ops.Normalize() >> ops.FillMissing() >> ops.LogOp()
     workflow = nvt.Workflow(cats + conts)
     _verify_workflow_on_tritonserver(tmpdir, workflow, df, "test_concatenate_dataframe")


### PR DESCRIPTION
Allow running triton inference on the cpu, using the 'model_instance_kind'
value to determine if we should restrict to running on CPU. If this is set
to CPU, we will restrict dataformats to only allow CPU representations.

This also fixes some minor errors running our triton integration on the cpu,
and after this change all unittests in tests/unit/test_triton_inference.py
pass even if there is no GPU available

Closes #739 