### PR TITLE
Fix installing with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,15 @@ from pybind11.setup_helpers import Pybind11Extension
 from pybind11.setup_helpers import build_ext as build_pybind11
 from setuptools import find_packages, setup
 
-import versioneer
+try:
+    import versioneer
+except ImportError:
+    # we have a versioneer.py file living in the same directory as this file, but
+    # if we're using pep 517/518 to build from pyproject.toml its not going to find it
+    # https://github.com/python-versioneer/python-versioneer/issues/193#issue-408237852
+    # make this work by adding this directory to the python path
+    sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+    import versioneer
 
 
 class build_pybind_and_proto(build_pybind11):


### PR DESCRIPTION
Installing with pip fails because of a 'versioneer' not found error. This
error seems to be related to using a newer version of pip alongside with the
build_system in pyproject.toml from pep 517/518.

Fix by adding the current directory to the python path as suggested in
https://github.com/python-versioneer/python-versioneer/issues/193 if the
versioneer import fails

Closes https://github.com/NVIDIA/NVTabular/issues/973
