### PR TITLE
Use requirements.txt file for conda recipe

### DIFF
--- a/conda/recipes/meta.yaml
+++ b/conda/recipes/meta.yaml
@@ -7,6 +7,7 @@
 {% set minor_version = version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
+{% set setup_py_data = load_setup_py_data() %}
 
 package:
   name: nvtabular
@@ -22,18 +23,18 @@ build:
 
 requirements:
   build:
-    - python x.x
+    - python
     - setuptools
     - pybind11>=2.7.0
     - protobuf>=3.0.0
   run:
-    - python>=3.7.0
+  {% for req in setup_py_data.get('install_requires', []) %}
+    - {{ req }}
+  {% endfor %}
+    - python
     - cudf>=21.06.*
     - dask-cudf>=21.06.*
     - cupy>=7.2.0,<9.0.0a
-    - dask==2021.5.1
-    - distributed==2021.5.1
-    - PyYAML>=5.3
     - nvtx>=0.2.1
 
 about:

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ def parse_requirements(filename):
     return [line for line in lineiter if line and not line.startswith("#")]
 
 
-install_reqs = parse_requirements("./requirements.txt") if not os.getenv("CONDA_BUILD") else None
+install_reqs = parse_requirements("./requirements.txt")
 
 setup(
     name="nvtabular",


### PR DESCRIPTION
We were missing tqdm from our conda package. Fix by picking up all requirements
from our requirements.txt file (from the setup.py 'install_requires' section).
