### PR TITLE
Rework `WorkflowNode` column methods to be easier to think about

### DIFF
--- a/nvtabular/inference/triton/__init__.py
+++ b/nvtabular/inference/triton/__init__.py
@@ -397,7 +397,7 @@ def _generate_nvtabular_config(
     if output_model == "hugectr":
         config.instance_group.append(model_config.ModelInstanceGroup(kind=2))
 
-        for column in workflow.output_node.input_column_names:
+        for column in workflow.output_node.input_columns.names:
             dtype = workflow.input_dtypes[column]
             config.input.append(
                 model_config.ModelInput(name=column, data_type=_convert_dtype(dtype), dims=[-1])

--- a/nvtabular/inference/triton/model.py
+++ b/nvtabular/inference/triton/model.py
@@ -41,7 +41,6 @@ from triton_python_backend_utils import (
 )
 
 import nvtabular
-from nvtabular import ColumnSelector
 from nvtabular.dispatch import _concat_columns, _is_list_dtype
 from nvtabular.inference.triton import _convert_tensor, get_column_types
 from nvtabular.inference.triton.data_conversions import convert_format
@@ -290,7 +289,7 @@ def _transform_tensors(input_tensors, workflow_node):
                 tensors, kind = convert_format(tensors, kind, workflow_node.inference_supports)
 
             tensors = workflow_node.op.transform(
-                ColumnSelector(workflow_node.input_column_names),
+                workflow_node.input_columns,
                 tensors,
             )
 

--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -448,7 +448,7 @@ class Categorify(StatOperator):
             cat_names, _ = _get_multicolumn_names(
                 col_selector, col_selector.grouped_names, self.name_sep
             )
-            return cat_names
+            return ColumnSelector(cat_names)
         return ColumnSelector(flatten(col_selector.names, container=tuple))
 
     def get_embedding_sizes(self, columns):

--- a/nvtabular/ops/join_external.py
+++ b/nvtabular/ops/join_external.py
@@ -198,9 +198,12 @@ class JoinExternal(Operator):
     transform.__doc__ = Operator.transform.__doc__
 
     def output_column_names(self, columns):
-        if self.columns_ext:
-            return ColumnSelector(list(set(columns + self.columns_ext)))
-        return ColumnSelector(list(set(columns + list(self._ext.columns))))
+        ext_columns = self.columns_ext if self.columns_ext else self._ext.columns
+
+        # This maintains the order which set() does not
+        combined = dict.fromkeys(columns + list(ext_columns)).keys()
+
+        return ColumnSelector(list(combined))
 
 
 def _check_partition_count(df):

--- a/nvtabular/ops/join_external.py
+++ b/nvtabular/ops/join_external.py
@@ -199,7 +199,7 @@ class JoinExternal(Operator):
 
     def output_column_names(self, columns):
         if self.columns_ext:
-            return list(set(columns + self.columns_ext))
+            return ColumnSelector(list(set(columns + self.columns_ext)))
         return ColumnSelector(list(set(columns + list(self._ext.columns))))
 
 

--- a/nvtabular/workflow/node.py
+++ b/nvtabular/workflow/node.py
@@ -207,6 +207,28 @@ class WorkflowNode:
         return f"<WorkflowNode {self.label}{output}>"
 
     @property
+    def input_columns(self):
+        dependencies = self.dependencies or set()
+
+        if self.parents:
+            parent_selectors = [
+                parent.selector for parent in self.parents if parent not in dependencies
+            ]
+
+            return sum(parent_selectors, ColumnSelector())
+        else:
+            return self.selector
+
+    @property
+    def output_columns(self):
+        if self.op:
+            return self.op.output_column_names(self.input_columns)
+        elif self.kind and "[" in self.kind and "]" in self.kind:
+            return self.selector
+        else:
+            return self.input_columns
+
+    @property
     def flattened_columns(self):
         return list(flatten(self.selector, container=tuple))
 

--- a/nvtabular/workflow/node.py
+++ b/nvtabular/workflow/node.py
@@ -16,8 +16,6 @@
 import collections.abc
 import warnings
 
-from dask.core import flatten
-
 from nvtabular.columns import ColumnSelector
 from nvtabular.ops import LambdaOp, Operator
 
@@ -227,10 +225,6 @@ class WorkflowNode:
             return self.selector
         else:
             return self.input_columns
-
-    @property
-    def flattened_columns(self):
-        return list(flatten(self.selector, container=tuple))
 
     @property
     def label(self):

--- a/nvtabular/workflow/node.py
+++ b/nvtabular/workflow/node.py
@@ -233,18 +233,6 @@ class WorkflowNode:
         return list(flatten(self.selector, container=tuple))
 
     @property
-    def input_column_names(self):
-        """Returns the names of columns in the main chain"""
-        dependencies = self.dependencies or set()
-
-        return [
-            col
-            for parent in self.parents
-            for col in parent.selector.grouped_names
-            if parent not in dependencies
-        ]
-
-    @property
     def label(self):
         if self.op:
             return self.op.label

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -34,7 +34,6 @@ from dask.core import flatten
 from nvtabular.dispatch import _concat_columns
 from nvtabular.io.dataset import Dataset
 from nvtabular.ops import StatOperator
-from nvtabular.ops.operator import ColumnSelector
 from nvtabular.utils import _ensure_optimize_dataframe_graph, global_dask_client
 from nvtabular.worker import clean_worker_cache
 from nvtabular.workflow.node import WorkflowNode, _merge_add_nodes, iter_nodes
@@ -151,8 +150,7 @@ class Workflow:
 
                 op = workflow_node.op
                 try:
-                    col_selector = ColumnSelector(workflow_node.input_column_names)
-                    stats.append(op.fit(col_selector, transformed_ddf))
+                    stats.append(op.fit(workflow_node.input_columns, transformed_ddf))
                     ops.append(op)
                 except Exception:
                     LOG.exception("Failed to fit operator %s", workflow_node.op)
@@ -378,8 +376,7 @@ def _transform_partition(root_df, workflow_nodes):
         # apply the operator if necessary
         if workflow_node.op:
             try:
-                col_selector = ColumnSelector(workflow_node.input_column_names)
-                df = workflow_node.op.transform(col_selector, df)
+                df = workflow_node.op.transform(workflow_node.input_columns, df)
             except Exception:
                 LOG.exception("Failed to transform operator %s", workflow_node.op)
                 raise

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -296,8 +296,8 @@ class Workflow:
             stat.op.clear()
 
     def _input_columns(self):
-        input_nodes = set(node for node in iter_nodes([self.output_node]) if not node.parents)
-        return list(set(col for node in input_nodes for col in node.flattened_columns))
+        input_nodes = list(set(node for node in iter_nodes([self.output_node]) if not node.parents))
+        return list(set(col for node in input_nodes for col in node.input_columns.names))
 
     def _clear_worker_cache(self):
         # Clear worker caches to be "safe"
@@ -311,7 +311,7 @@ def _transform_ddf(ddf, workflow_nodes, meta=None):
     if isinstance(workflow_nodes, WorkflowNode):
         workflow_nodes = [workflow_nodes]
 
-    columns = list(flatten(cg.flattened_columns for cg in workflow_nodes))
+    columns = list(flatten(wfn.output_columns.names for wfn in workflow_nodes))
 
     # Check if we are only selecting columns (no transforms).
     # If so, we should perform column selection at the ddf level.
@@ -354,13 +354,13 @@ def _transform_partition(root_df, workflow_nodes):
     """Transforms a single partition by appyling all operators in a WorkflowNode"""
     output = None
     for workflow_node in workflow_nodes:
-        unique_flattened_cols = _get_unique(workflow_node.flattened_columns)
+        unique_flattened_cols = _get_unique(workflow_node.output_columns.names)
         # collect dependencies recursively if we have parents
         if workflow_node.parents:
             df = None
             columns = None
             for parent in workflow_node.parents:
-                unique_flattened_cols_parent = _get_unique(parent.flattened_columns)
+                unique_flattened_cols_parent = _get_unique(parent.output_columns.names)
                 parent_df = _transform_partition(root_df, [parent])
                 if df is None or not len(df):
                     df = parent_df[unique_flattened_cols_parent]

--- a/tests/integration/common/utils.py
+++ b/tests/integration/common/utils.py
@@ -117,7 +117,7 @@ def _run_query(
     workflow = nvt.Workflow.load(workflow_path)
 
     if input_cols_name is None:
-        batch = cudf.read_csv(data_path, nrows=n_rows)[workflow.output_node.input_column_names]
+        batch = cudf.read_csv(data_path, nrows=n_rows)[workflow.output_node.input_columns.names]
     else:
         batch = cudf.read_csv(data_path, nrows=n_rows)[input_cols_name]
 

--- a/tests/unit/workflow/test_workflow_node.py
+++ b/tests/unit/workflow/test_workflow_node.py
@@ -3,8 +3,34 @@ import pytest
 
 from nvtabular import Dataset, Workflow, WorkflowNode, dispatch
 from nvtabular.columns import ColumnSelector
-from nvtabular.ops import Categorify, Rename
+from nvtabular.ops import Categorify, FillMissing, Rename, TargetEncoding
 from tests.conftest import assert_eq
+
+
+def test_input_output_column_names():
+    input_node = ["a", "b", "c"] >> FillMissing()
+    assert input_node.input_columns.names == ["a", "b", "c"]
+    assert input_node.output_columns.names == ["a", "b", "c"]
+
+    chained_node = input_node >> Categorify()
+    assert chained_node.input_columns.names == ["a", "b", "c"]
+    assert chained_node.output_columns.names == ["a", "b", "c"]
+
+    selection_node = input_node[["b", "c"]]
+    assert selection_node.input_columns.names == ["a", "b", "c"]
+    assert selection_node.output_columns.names == ["b", "c"]
+
+    addition_node = input_node + ["d"]
+    assert addition_node.input_columns.names == ["a", "b", "c", "d"]
+    assert addition_node.output_columns.names == ["a", "b", "c", "d"]
+
+    rename_node = input_node >> Rename(postfix="_renamed")
+    assert rename_node.input_columns.names == ["a", "b", "c"]
+    assert rename_node.output_columns.names == ["a_renamed", "b_renamed", "c_renamed"]
+
+    dependency_node = input_node >> TargetEncoding("d")
+    assert dependency_node.input_columns.names == ["a", "b", "c"]
+    assert dependency_node.output_columns.names == ["TE_a_d", "TE_b_d", "TE_c_d"]
 
 
 def test_workflow_node_select():


### PR DESCRIPTION
I've been having trouble understanding what's going on with various parts of the code that call `input_column_names` and `flattened_columns`, because it's unclear whether those are the input or the output columns. This PR refactors those methods out and replaces them with `input_columns` and `output_columns` to make some of the other graph/workflow code we're working on easier to think through.

`input_column_names` is obviously for the input, but `flattened_columns` is ambiguous. It gets trickier to think about when `WorkflowNode.selector` is added to the picture, because that's also currently a list of column names, which ought to represent the input columns for the current node but actually represents the input columns for the next node (i.e. the current node's output.)

We're trying to refactor our way out of this conundrum by changing some things about how the graph works:

* `WorkflowNode.selector` should represent the current node's input columns
* Then we wouldn't need separate "input nodes" at the beginning of the graph that have a selector but no op
* In order to make that work with `+` nodes, we need to be able to use the selector to grab additional columns from the root dataframe of the workflow
* In order to make that work, we need unambiguous input/output column methods on `WorkflowNode` to use in `Workflow._transform_ddf` (which this PR provides.)
