### PR TITLE
Move dataset schema inference into `Dataset` and automatically fit `Workflow` to schema (as needed)

### DIFF
--- a/nvtabular/columns/schema.py
+++ b/nvtabular/columns/schema.py
@@ -23,6 +23,7 @@ class ColumnSchema:
 
     name: Text
     tags: Optional[List[Text]] = field(default_factory=list)
+    dtype: Optional[object] = None
 
     def __str__(self) -> str:
         return self.name

--- a/nvtabular/io/dataset.py
+++ b/nvtabular/io/dataset.py
@@ -29,6 +29,7 @@ from dask.utils import natural_sort_key, parse_bytes
 from fsspec.core import get_fs_token_paths
 from fsspec.utils import stringify_path
 
+from nvtabular.columns.schema import ColumnSchema, Schema
 from nvtabular.dispatch import _convert_data, _hex_to_int, _is_dataframe_object
 from nvtabular.io.shuffle import _check_shuffle_arg
 from nvtabular.utils import global_dask_client
@@ -1050,6 +1051,22 @@ class Dataset:
             return result.compute()
         else:
             return result
+
+    def infer_schema(self, n=1):
+        """Create a schema containing the column names and inferred dtypes of the Dataset
+
+        Args:
+            n (int, optional): Number of rows to sample to infer the dtypes. Defaults to 1.
+        """
+        sampled_dtypes = self.sample_dtypes(n)
+        dtypes = dict(zip(sampled_dtypes.index, sampled_dtypes))
+
+        column_schemas = []
+        for column, dtype in dtypes.items():
+            col_schema = ColumnSchema(column, dtype=dtype)
+            column_schemas.append(col_schema)
+
+        return Schema(column_schemas)
 
     def sample_dtypes(self, n=1):
         """Return the real dtypes of the Dataset

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -109,10 +109,11 @@ class Workflow:
         -------
         Dataset
         """
-        if not self.output_schema:
-            self.fit(dataset)
-
         self._clear_worker_cache()
+
+        if not self.output_schema:
+            self.fit_schema(dataset.infer_schema())
+
         ddf = dataset.to_ddf(columns=self._input_columns())
         return Dataset(
             _transform_ddf(ddf, self.output_node, self.output_dtypes),

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -32,7 +32,7 @@ import pandas as pd
 from dask.core import flatten
 
 import nvtabular
-from nvtabular.columns import ColumnSchema, Schema
+from nvtabular.columns import Schema
 from nvtabular.dispatch import _concat_columns
 from nvtabular.io.dataset import Dataset
 from nvtabular.ops import StatOperator
@@ -167,15 +167,11 @@ class Workflow:
             data should be the training dataset only.
         """
         self._clear_worker_cache()
+
+        if not self.output_schema:
+            self.fit_schema(dataset.infer_schema())
+
         ddf = dataset.to_ddf(columns=self._input_columns())
-
-        # Create a schema for the dataset
-        col_schemas = []
-        for column_name in ddf.columns:
-            col_schemas.append(ColumnSchema(column_name))
-        input_schema = Schema(col_schemas)
-
-        self.fit_schema(input_schema)
 
         # Get a dictionary mapping all StatOperators we need to fit to a set of any dependant
         # StatOperators (having StatOperators that depend on the output of other StatOperators

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -38,6 +38,13 @@ from nvtabular.io.parquet import GPUParquetWriter
 from tests.conftest import allcols_csv, mycols_csv, mycols_pq, run_in_context
 
 
+@pytest.mark.parametrize("engine", ["parquet"])
+def test_dataset_infer_schema(dataset, engine):
+    schema = dataset.infer_schema()
+    expected_columns = ["timestamp", "id", "label", "name-cat", "name-string", "x", "y", "z"]
+    assert schema.column_names == expected_columns
+
+
 @pytest.mark.parametrize("engine", ["csv", "parquet", "csv-no-header"])
 def test_shuffle_gpu(tmpdir, datasets, engine):
     num_files = 2


### PR DESCRIPTION
This PR creates an `infer_schema` method on `Dataset` that uses `sample_dtypes` to get the column names and dtypes from the ddf, then uses that information to create `Schema` and `ColumnSchema` objects to represent the dataset. This allows `Workflow.fit()` to avoid reading in all the columns of the dataset when only some of them are needed.

To make the schema fitting process smooth and break as little calling code as possible, this PR also checks whether or not the output schema of the `Workflow` has already been computed at the beginning of the `fit` and `transform` methods, and runs `fit_schema` to compute the output schema if not.

