### PR TITLE
Make make_feature_column_workflow work with vocabularies of varying size

### DIFF
--- a/nvtabular/framework_utils/tensorflow/feature_column_utils.py
+++ b/nvtabular/framework_utils/tensorflow/feature_column_utils.py
@@ -227,9 +227,8 @@ def make_feature_column_workflow(feature_columns, label_name, category_dir=None)
         features += features_replaced_buckets
 
     if len(categorifies) > 0:
-        features += ColumnSelector(list(categorifies.keys())) >> Categorify(
-            vocabs=pd.DataFrame(categorifies)
-        )
+        vocabs = {column: pd.Series(vocab) for column, vocab in categorifies.items()}
+        features += ColumnSelector(list(categorifies.keys())) >> Categorify(vocabs=vocabs)
 
     if len(hashes) > 0:
         features += ColumnSelector(list(hashes.keys())) >> HashBucket(hashes)

--- a/tests/unit/framework_utils/test_tf_feature_columns.py
+++ b/tests/unit/framework_utils/test_tf_feature_columns.py
@@ -14,7 +14,7 @@ def test_feature_column_utils():
         ),
         tf.feature_column.embedding_column(
             tf.feature_column.categorical_column_with_vocabulary_list(
-                "vocab_2", ["1", "2", "3", "4"]
+                "vocab_2", ["1", "2", "3", "4", "5"]
             ),
             32,
         ),

--- a/tests/unit/ops/test_ops.py
+++ b/tests/unit/ops/test_ops.py
@@ -472,7 +472,7 @@ def test_lambdaop_misalign(cpu):
 @pytest.mark.parametrize("freq_threshold", [0, 1, 2])
 @pytest.mark.parametrize("cpu", _CPU)
 @pytest.mark.parametrize("dtype", [None, np.int32, np.int64])
-@pytest.mark.parametrize("vocabs", [None, pd.DataFrame({"Authors": [f"User_{x}" for x in "ACBE"]})])
+@pytest.mark.parametrize("vocabs", [None, {"Authors": pd.Series([f"User_{x}" for x in "ACBE"])}])
 def test_categorify_lists(tmpdir, freq_threshold, cpu, dtype, vocabs):
     df = dispatch._make_df(
         {


### PR DESCRIPTION
`make_feature_column_workflow` fails in `Categorify` if features have vocabularies of varying sizes. This fix changes the type of parameter `vocabs` of `Categorify` to be a dictionary instead of DataFrame so that clients can provide dictionaries of varying sizes.

This fixes NVIDIA#1062.