### PR TITLE
Fix inference with pandas nullable dtypes

### DIFF
--- a/cpp/nvtabular/inference/categorify.cc
+++ b/cpp/nvtabular/inference/categorify.cc
@@ -48,6 +48,9 @@ struct ColumnMapping {
             // so we're categorifying bool columns in the rossmann dataset - which makes little
             // sense but we have to handle I guess ?
             mapping_int[value.ptr() == Py_True] = i;
+          } else if (PyLong_Check(value.ptr())) {
+            auto key = py::cast<int64_t>(value);
+            mapping_int[key] = i;
           } else {
             std::stringstream error;
             error << "Don't know how to handle column " << column_name << " @ " << filename;


### PR DESCRIPTION
Using pandas 1.3 failed on the inference movielens test - because of switching
to nullable types. Fix by adding a test to convert integer values (rather than
whole integer arrays) of object dtypes when loading the categorical mapping.

Fixes #1098
