### PR TITLE
Fix HugeCTR inference example

### DIFF
--- a/examples/getting-started-movielens/inference-HugeCTR/Triton-Inference-with-HugeCTR.ipynb
+++ b/examples/getting-started-movielens/inference-HugeCTR/Triton-Inference-with-HugeCTR.ipynb
@@ -79,7 +79,6 @@
    ],
    "source": [
     "%%writefile '/model/models/ps.json'\n",
-    "# fmt: off\n",
     "{\n",
     "    \"supportlonglong\": true,\n",
     "    \"models\": [\n",


### PR DESCRIPTION
We were writing out an invalid JSON file. Fix.

