### PR TITLE
Fix categorify counts

### DIFF
--- a/nvtabular/dispatch.py
+++ b/nvtabular/dispatch.py
@@ -379,9 +379,8 @@ def _make_df(_like_df=None, device=None):
         return pd.DataFrame(_like_df)
     elif isinstance(_like_df, (cudf.DataFrame, cudf.Series)):
         return cudf.DataFrame(_like_df)
-    elif isinstance(_like_df, dict) and len(_like_df) > 0:
+    elif device is None and isinstance(_like_df, dict) and len(_like_df) > 0:
         is_pandas = all(isinstance(v, pd.Series) for v in _like_df.values())
-
         return pd.DataFrame(_like_df) if is_pandas else cudf.DataFrame(_like_df)
     if device == "cpu":
         return pd.DataFrame(_like_df)

--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -981,6 +981,12 @@ def _write_uniques(dfs, base_path, col_selector: ColumnSelector, options: FitOpt
                     [_nullable_series([None], df, df[col].dtype), df[col]],
                     ignore_index=True,
                 )
+                if name_count in df:
+                    new_cols[name_count] = _concat(
+                        [_nullable_series([0], df, df[name_count].dtype), df[name_count]],
+                        ignore_index=True,
+                    )
+
             else:
                 # ensure None aka "unknown" stays at index 0
                 if name_count in df:
@@ -988,8 +994,9 @@ def _write_uniques(dfs, base_path, col_selector: ColumnSelector, options: FitOpt
                     df_1 = df.iloc[1:].sort_values(name_count, ascending=False, ignore_index=True)
                     df = _concat([df_0, df_1])
                 new_cols[col] = df[col].copy(deep=False)
-            if name_count in df:
-                new_cols[name_count] = df[name_count].copy(deep=False)
+
+                if name_count in df:
+                    new_cols[name_count] = df[name_count].copy(deep=False)
         if nulls_missing:
             df = type(df)(new_cols)
         df.to_parquet(path, index=False, compression=None)
@@ -998,6 +1005,7 @@ def _write_uniques(dfs, base_path, col_selector: ColumnSelector, options: FitOpt
         for c in col_selector.names:
             df_null[c] = df_null[c].astype(df[c].dtype)
         df_null.to_parquet(path, index=False, compression=None)
+
     del df
     return path
 


### PR DESCRIPTION
The counts written out by categorify to parquet files were incorrect in the
case where there were nulls in the dataset. This was because the counts
were being calculated from before inserting the 'null' placeholder column
when writing out. Fix and add a unittest.

Closes #1128
