### PR TITLE
Avoid unncessary dtype conversion for invalid Dask metadata

### DIFF
--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -419,7 +419,6 @@ def _transform_ddf(ddf, workflow_nodes, meta=None, additional_columns=None):
         meta = type(ddf._meta)({k: [] for k in columns})
         for column, dtype in dtypes.items():
             meta[column] = meta[column].astype(dtype)
-        enforce_metadata = True
 
     elif not meta:
         # TODO: constructing meta like this loses dtype information on the ddf
@@ -428,14 +427,13 @@ def _transform_ddf(ddf, workflow_nodes, meta=None, additional_columns=None):
         # happesn during intermediate 'fit' transforms, so as long as statoperators
         # don't require dtype information on the DDF this doesn't matter all that much
         meta = type(ddf._meta)({k: [] for k in columns})
-        enforce_metadata = False
 
     return ddf.map_partitions(
         _transform_partition,
         workflow_nodes,
         additional_columns=additional_columns,
         meta=meta,
-        enforce_metadata=enforce_metadata,
+        enforce_metadata=False,
     )
 
 

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -419,6 +419,7 @@ def _transform_ddf(ddf, workflow_nodes, meta=None, additional_columns=None):
         meta = type(ddf._meta)({k: [] for k in columns})
         for column, dtype in dtypes.items():
             meta[column] = meta[column].astype(dtype)
+        enforce_metadata = True
 
     elif not meta:
         # TODO: constructing meta like this loses dtype information on the ddf
@@ -427,12 +428,14 @@ def _transform_ddf(ddf, workflow_nodes, meta=None, additional_columns=None):
         # happesn during intermediate 'fit' transforms, so as long as statoperators
         # don't require dtype information on the DDF this doesn't matter all that much
         meta = type(ddf._meta)({k: [] for k in columns})
+        enforce_metadata = False
 
     return ddf.map_partitions(
         _transform_partition,
         workflow_nodes,
         additional_columns=additional_columns,
         meta=meta,
+        enforce_metadata=enforce_metadata,
     )
 
 

--- a/tests/unit/test_dask_nvt.py
+++ b/tests/unit/test_dask_nvt.py
@@ -20,8 +20,10 @@ import os
 
 import cudf
 import dask_cudf
+import pandas as pd
 import pytest
 from dask.dataframe import assert_eq
+from dask.dataframe import from_pandas as dd_from_pandas
 from dask.dataframe import read_parquet as dd_read_parquet
 
 from nvtabular import ColumnSelector, Dataset, Workflow, ops
@@ -276,3 +278,18 @@ def test_dask_preproc_cpu(client, tmpdir, datasets, engine, shuffle, cpu):
         df_disk.sort_values(["id", "x"])[["name-string", "label"]],
         check_index=False,
     )
+
+
+@pytest.mark.parametrize("cpu", [None, True])
+def test_filtered_partition(tmpdir, cpu):
+    # Toy DataFrame example
+    df = pd.DataFrame({"col": range(100)})
+    ddf = dd_from_pandas(df, npartitions=5)
+    dataset = Dataset(ddf, cpu=cpu)
+
+    # Workflow
+    filtered = ["col"] >> ops.Filter(lambda df: df["col"] < 75)
+    workflow = Workflow(filtered)
+
+    # Write result to disk
+    workflow.transform(dataset).to_parquet(str(tmpdir))


### PR DESCRIPTION
Closes #1097

NVTabular uses `map_partitions` to perform partition-wise transformations with Dask. In many cases, the `meta` argument to this utility is known to be wrong (all `float64` dtypes).  In that case, it does not make much sense to allow Dask to use `enforce_metadata=True` (the default behavior).  In fact, by asking Dask to enforce the `meta` dtypes, we are guarenteed to get incorrect dtypes for empty output partitions (causing issues like #1097).

<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
