### PR TITLE
Fix conda environment files

### DIFF
--- a/conda/environments/nvtabular_dev_cuda11.0.yml
+++ b/conda/environments/nvtabular_dev_cuda11.0.yml
@@ -5,54 +5,17 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - arrow-cpp=1.0.1
-  - asvdb
-  - black
-  - boost-cpp
-  - clang-tools=8.0.1
-  - clang=8.0.1
-  - cmake_setuptools>=0.1.3
-  - cmake>=3.18
+  - nvtabular
+  - python>=3.7
   - cudatoolkit=11.0
   - cudf>=21.08.*
-  - cupy>=7.2.0,<10.0.0a
-  - cython>=0.29,<0.30
   - dask-cuda>=21.08.*
   - dask-cudf>=21.08.*
+  - rmm>=21.08.*
   - dask==2021.7.1
   - distributed>=2021.7.1
-  - dlpack
-  - double-conversion
-  - fastavro>=0.22.9
-  - flake8
-  - flatbuffers
-  - fsspec>=0.6.0
-  - hypothesis
-  - ipython
-  - isort
-  - nbsphinx
-  - notebook>=0.5.0
-  - numba>=0.54.0
-  - numpydoc
-  - nvtabular
   - nvtx>=0.2.1
-  - pandas>=1.2.0
-  - pandoc=<2.0.0
-  - partd
-  - pip
-  - pre_commit
-  - pyarrow>=1.0.1
-  - pytest
-  - python>=3.7
-  - rapidjson
-  - recommonmark
-  - rmm>=21.08.*
+  - numba>=0.53.0
+  - dlpack
   - scikit-learn
-  - sphinx
-  - sphinx_rtd_theme
-  - sphinxcontrib-websupport
-  - streamz
-  - tqdm
-  - pip:
-      - graphviz
-      - sphinx-markdown-tables
+  - asvdb

--- a/conda/environments/nvtabular_dev_cuda11.2.yml
+++ b/conda/environments/nvtabular_dev_cuda11.2.yml
@@ -5,54 +5,18 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - arrow-cpp=1.0.1
-  - asvdb
-  - black
-  - boost-cpp
-  - clang-tools=8.0.1
-  - clang=8.0.1
-  - cmake_setuptools>=0.1.3
-  - cmake>=3.18
+  - nvtabular
+  - python>=3.7
   - cudatoolkit=11.2
   - cudf>=21.08.*
-  - cupy>=7.2.0,<10.0.0a
-  - cython>=0.29,<0.30
   - dask-cuda>=21.08.*
   - dask-cudf>=21.08.*
+  - rmm>=21.08.*
   - dask==2021.7.1
   - distributed>=2021.7.1
-  - dlpack
-  - double-conversion
-  - fastavro>=0.22.9
-  - flake8
-  - flatbuffers
   - fsspec>=0.6.0
-  - hypothesis
-  - ipython
-  - isort
-  - nbsphinx
-  - notebook>=0.5.0
-  - numba>=0.54.0
-  - numpydoc
-  - nvtabular
   - nvtx>=0.2.1
-  - pandas>=1.2.0
-  - pandoc=<2.0.0
-  - partd
-  - pip
-  - pre_commit
-  - pyarrow>=1.0.1
-  - pytest
-  - python>=3.7
-  - rapidjson
-  - recommonmark
-  - rmm>=21.08.*
+  - numba>=0.53.0
+  - dlpack
   - scikit-learn
-  - sphinx
-  - sphinx_rtd_theme
-  - sphinxcontrib-websupport
-  - streamz
-  - tqdm
-  - pip:
-      - graphviz
-      - sphinx-markdown-tables
+  - asvdb


### PR DESCRIPTION
Our conda environment files were failing to install, because it was overspecifying required
versions of transitive dependencies. For instance, we specified the version of pandas required
but that conflicts with the version that we pick up from cudf (likewise pyarrow etc).

Fix by removing transitive dependencies like pandas/pyarrow etc-  and instead rely on the
fact that these are dependencies of cudf. This means we won't have to keep updating version
numbers ourselves to keep in sync with cudf. Also remove development dependencies, which can
be picked up from requirements-dev.txt instead.

